### PR TITLE
refactor(claude): remove git/bash rules covered by system prompt

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -16,25 +16,4 @@ When writing _for_ me or _as_ me (blog posts, docs, messages), use the `writing-
 - **Reflect after repeated failures.** If the same approach fails twice, pause to state observations and critically reassess before continuing. Don't just try more variants.
 - **Understand before executing.** When the user proposes an approach, first understand what they're trying to accomplish and why. Surface better alternatives early if they exist. Once the motivation is clear, proceed with the best approach. Don't silently substitute a different one mid-task.
 
-## Bash Commands
 
-**Do not chain commands with `&&` in a single Bash call.** Run them as separate tool calls instead (in parallel when independent). Compound commands like `cd /path && git add file && git commit` cause permission prompts to misfire, prompting for `cd:*` instead of the actual command.
-
-Specifically:
-
-- Never prefix a command with `cd <path> &&`. If you need to run a command in a different directory, `cd` first as its own Bash call, then run the command separately.
-- Never use `git -C <path>`. Just `cd` to the directory first.
-- Never chain independently-approvable commands (e.g. `git log && git add`). Make separate tool calls.
-- Prefer the Write tool over heredoc/cat for creating files. If you must use a heredoc in Bash, keep it short.
-
-## managing git directories
-
-### git add
-
-ALWAYS use `git add` with specific files that have been updated. NEVER use `git add .` or `git add -A`.
-
-IF adding files that look like they are agent configuration, or adding planning documentation, ALWAYS prompt the user to confirm if they should be included or not.
-
-### git commit
-
-PREFER writing out a commit message to `scratch/`, and save it to a name reflecting what is being committed. Then use `git commit -F scratch/path-to-message.txt`


### PR DESCRIPTION
The Bash Commands and git sections duplicated or contradicted Claude Code's built-in system prompt (which already requires heredocs for commit messages and warns against `git add .` / `git add -A`).

The `&&` misfire rule is removed pending validation via the test harness (bean dotfiles-dcjj). If the permission-prompt misfire still reproduces under current Claude Code + sandbox, a targeted rule can be re-added with documented evidence.