### PR TITLE
Validate agent SSH key: fix false-pass auth check, add per-org SSO, wire into claudeconfig

### DIFF
--- a/.beans/dotfiles-cr2m--generalize-claudeconfigsh-to-apply-validate-claude.md
+++ b/.beans/dotfiles-cr2m--generalize-claudeconfigsh-to-apply-validate-claude.md
@@ -1,0 +1,58 @@
+---
+# dotfiles-cr2m
+title: Generalize claudeconfig.sh to apply + validate Claude config (agent SSH key)
+status: completed
+type: feature
+priority: normal
+created_at: 2026-06-15T19:40:12Z
+updated_at: 2026-06-15T19:44:44Z
+---
+
+Generalize `claudeconfig.sh` from "apply Claude config" to "apply AND validate my
+Claude config," starting with the agent SSH key (the motivating gap from
+dotfiles-w4tk).
+
+## Behavior
+
+After the existing apply phases (symlink CLAUDE.md, sandbox dirs, generate
+settings.json, marketplaces), add a final **validate** phase that runs
+`bin/check-agent-ssh-key "$ROLE"` for the active role. Fail-loud: validation
+failure makes `claudeconfig.sh` exit non-zero. Apply always completes first, so a
+validation failure never leaves config half-written -- it only affects exit code.
+
+## Email is derived, not hardcoded
+
+`check-agent-ssh-key` needs `--email`. The agent email already lives in the role's
+gitconfig include (`home/.gitconfig.d/claude-agent-<role>` -> `user.email`). Read it
+with `git config --file`, so there's one source of truth (no work->gusto.com /
+home->gmail.com mapping to drift).
+
+## Skip when nothing to check
+
+If a role has no `claude-agent-<role>` include (e.g. `base`), there's no agent
+identity -> validate phase is a no-op for that role.
+
+## Escape hatch: --skip-ssh-check
+
+`--skip-ssh-check` flag (and `SKIP_SSH_CHECK=1` for non-interactive) bypasses only
+the key validation, leaving apply intact. Needed because on a fresh machine
+claudeconfig runs (setup step 4) BEFORE the key is registered/SSO-authorized
+(steps 2/3/6), and for offline runs. setup-agent-ssh-key's "re-run claudeconfig.sh"
+step becomes `claudeconfig.sh --skip-ssh-check`.
+
+## Structured for growth
+
+Validate phase is its own function so future config checks (settings.json schema,
+plugin health) can be added there later. Not building those now (YAGNI).
+
+## Known consequence
+
+Turning this on means the next `claudeconfig.sh` run fails until `gh auth refresh -h
+github.com -s user:email` (the real gap check flags today) or `--skip-ssh-check`.
+Fail-loud working as intended.
+
+## Checklist
+- [x] Arg/env parse for --skip-ssh-check / SKIP_SSH_CHECK
+- [x] validate_agent_ssh_key() phase (derive email, skip when no agent, fail loud)
+- [x] Wire into setup-agent-ssh-key step 4 (--skip-ssh-check)
+- [x] Test: arg parse, --help, bad-arg (exit 2), email derivation (work -> +agent@gusto.com), base no-op, --skip-ssh-check early-return, and live check exit=1 (fail-loud trigger via current user:email gh-scope gap)

--- a/.beans/dotfiles-w4tk--add-per-org-saml-sso-probe-to-check-agent-ssh-key.md
+++ b/.beans/dotfiles-w4tk--add-per-org-saml-sso-probe-to-check-agent-ssh-key.md
@@ -1,0 +1,84 @@
+---
+# dotfiles-w4tk
+title: Add per-org SAML SSO probe to check-agent-ssh-key (work role only)
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-15T17:35:52Z
+updated_at: 2026-06-15T17:45:50Z
+---
+
+`bin/check-agent-ssh-key` step 7 verifies plain `ssh -T git@github.com` auth, but
+that only proves the key authenticates as the user. It does NOT verify per-org
+SAML SSO authorization, which is a separate, per-org, browser-only grant.
+
+## Why this matters (found 2026-06-15)
+
+After the June 13 fix (`dotfiles-niec`, sshCommand `-F /dev/null`) made the work
+agent genuinely use `~/.ssh/agents/work/id_ed25519` instead of leaking the laptop
+key, the dedicated key authenticated to github.com fine but was not SSO-authorized
+for **guideline-app**. `git ls-remote git@github.com:guideline-app/bamboo-cli.git`
+returned:
+
+    ERROR: The 'guideline-app' organization has enabled or enforced SAML SSO.
+
+Gusto was already authorized (`Gusto/web` ls-remote returned a SHA). The existing
+check passed clean the whole time because it never probes an org repo. SSO grant is
+browser-only (github.com/settings/keys -> Configure SSO -> Authorize); not exposed
+via gh/API.
+
+## What to add
+
+A new check that runs `git ls-remote` against one known repo per org and detects
+the SAML SSO error string ("enabled or enforced SAML SSO"). Pass = SHA returned,
+fail = SSO error (point at github.com/settings/keys -> Configure SSO).
+
+## Scope: work role ONLY
+
+Only the **work** role has org-scoped access (Gusto, guideline-app). The home/
+personal role uses the gmail identity against personal repos with no org SSO. Gate
+the new check on `ROLE == work` (or skip cleanly for any role with no configured
+org list) so the personal role doesn't false-fail.
+
+## Implementation notes
+
+- Reuse the live sshCommand shape: `ssh -F /dev/null -i $KEY_PATH -o IdentitiesOnly=yes -o IdentityAgent=SSH_AUTH_SOCK -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10`.
+- Org -> probe-repo map (small, in-script or configurable): Gusto -> Gusto/web, guideline-app -> guideline-app/bamboo-cli.
+- Treat a returned HEAD SHA as pass; grep stderr for "SAML SSO" as the fail signal.
+
+## Resolution (shipped 2026-06-15)
+
+Added step 8 to `bin/check-agent-ssh-key`: a per-org SAML SSO probe gated on
+`ROLE == work`. Runs `git ls-remote` against a canary repo per org using the live
+agent sshCommand shape (`-F /dev/null -i $KEY_PATH ... IdentityAgent=SSH_AUTH_SOCK
+BatchMode=yes`), then:
+
+- returned 40-hex HEAD SHA -> pass ("authorized for SAML SSO")
+- "enabled or enforced SAML SSO" -> fail (points at github.com/settings/keys -> Configure SSO -> <org>)
+- anything else -> inconclusive (could not reach repo)
+
+Org canaries: `Gusto -> Gusto/web`, `guideline-app -> guideline-app/bamboo-cli`.
+Non-work roles get an empty org list and skip the block entirely.
+
+Also updated the top-of-file checklist comment and `bin/CLAUDE.md`.
+
+Verified live: `bin/check-agent-ssh-key work --email josh.nichols+agent@gusto.com`
+reports both orgs authorized. (The unrelated `user:email` gh-scope failure is a
+local gh token issue, not this change.)
+
+## Also fixed: step 7 was a false pass
+
+While verifying step 8, found step 7 (`ssh -T github.com`) had the same
+laptop-key leak that `dotfiles-niec` fixed in the live sshCommand: it omitted
+`-F /dev/null`, so `~/.ssh/config`'s additive `Host *` `IdentityFile ~/.ssh/id_ed25519`
+stayed a candidate (IdentitiesOnly=yes does NOT drop config-supplied identities).
+Proved with `ssh -v`: the server accepted the laptop key `SHA256:bo+XtP6...`, not
+the agent key `SHA256:mwyw...`. Because both keys are on the same `technicalpickles`
+account, the "Hi <user>!" greeting was identical, so step 7 reported a green check
+even though the agent key was never exercised -- it would pass even for a broken or
+unregistered agent key.
+
+Fix: added `-F /dev/null` to step 7's ssh, plus a fingerprint assertion that parses
+the `-v` "Server accepts key" line and requires the accepted fingerprint to equal
+this key's `$LOCAL_FP`. Now step 7 genuinely tests the agent key and fails loudly if
+the wrong key satisfies auth. Verified: reports "works with this key".

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,8 +3,6 @@
     "superpowers-developing-for-claude-code@superpowers-marketplace": true
   },
   "permissions": {
-    "allow": [
-      "Bash(bin/prettier:*)"
-    ]
+    "allow": ["Bash(bin/prettier:*)"]
   }
 }

--- a/.config/prettier/ignore
+++ b/.config/prettier/ignore
@@ -12,6 +12,11 @@ home/.vim/plugged
 # stuff that doesn't need formatting
 config/fish/fish_plugins
 
+# auto-generated issue-tracker files (beans); change constantly and contain
+# markdown-emphasis-like text (*, _) that prettier rewrites, breaking CI on
+# every push. Not hand-authored, so don't lint them.
+.beans/
+
 # stuff without prettier support
 *.fish
 .editorconfig

--- a/bin/CLAUDE.md
+++ b/bin/CLAUDE.md
@@ -26,4 +26,4 @@ Spotlight is kept enabled (Alfred requires it) but specific directories are excl
 - `bin/tmux-smart-open`: Open URLs/files on double-click in tmux
 - `bin/tmux-auto-rename-session`: Auto-name sessions after their directory
 - `bin/setup-agent-ssh-key`: Generate a per-role agent SSH identity (see [ADR 0031](../doc/adr/0031-role-scoped-agent-git-identity.md)). Accepts `--email <addr>` to override the default `joshua.nichols+<role>-agent@gmail.com` (e.g. for the work role: `--email josh.nichols+agent@gusto.com`).
-- `bin/check-agent-ssh-key`: Validate an agent SSH identity setup (local files, Keychain, GitHub registration, Claude settings). Pass the same `--email` used at setup time.
+- `bin/check-agent-ssh-key`: Validate an agent SSH identity setup (local files, Keychain, GitHub registration, Claude settings, and -- for the work role -- per-org SAML SSO authorization). Pass the same `--email` used at setup time.

--- a/bin/check-agent-ssh-key
+++ b/bin/check-agent-ssh-key
@@ -15,6 +15,7 @@ set -uo pipefail
 #   6. ~/.claude/settings.json wires GIT_CONFIG_GLOBAL to a gitconfig include
 #      file that overrides user.email, core.sshCommand, and gpg.ssh.program
 #   7. SSH can authenticate to github.com using this key
+#   8. (work role only) the key is authorized for each org's SAML SSO
 #
 # Exits 0 on all-pass, 1 if anything failed.
 
@@ -276,20 +277,83 @@ else
   check_fail "~/.claude/settings.json not found" "Run: DOTPICKLES_ROLE=$ROLE ./claudeconfig.sh"
 fi
 
-# --- 7. SSH auth to github.com ---
+# --- 7. SSH auth to github.com using THIS key ---
 # GitHub returns "Hi <user>!" on success, exit code 1 (expected, no shell).
+#
+# Two non-obvious things this guards against:
+#   - -F /dev/null: ~/.ssh/config's `Host *` adds `IdentityFile ~/.ssh/id_ed25519`
+#     (the human laptop key). IdentityFile is additive and IdentitiesOnly=yes does
+#     NOT drop config-supplied identities -- only extra agent-offered ones. Without
+#     -F, ssh offers the laptop key first, the server accepts it, and the test
+#     "passes" via the wrong key. Because both keys live on the same GitHub account,
+#     the "Hi <user>!" greeting is identical either way, so the username alone can't
+#     catch it. -F /dev/null makes the explicit `-i` the only candidate.
+#   - fingerprint assertion: we parse the -v trace's "Server accepts key" line and
+#     require the accepted fingerprint to equal THIS key's. Belt-and-suspenders so a
+#     future config leak can never let a different key satisfy the check silently.
 info "Testing SSH auth to github.com (this may take a second)..."
-ssh_out=$(ssh -i "$KEY_PATH" \
+ssh_out=$(ssh -v -F /dev/null -i "$KEY_PATH" \
   -o IdentitiesOnly=yes \
   -o IdentityAgent=SSH_AUTH_SOCK \
   -o StrictHostKeyChecking=accept-new \
   -o ConnectTimeout=10 \
   -T git@github.com 2>&1 || true)
+accepted_fp=$(echo "$ssh_out" | grep "Server accepts key:" | grep -oE 'SHA256:[A-Za-z0-9+/]+' | head -1)
 if echo "$ssh_out" | grep -q "successfully authenticated"; then
   gh_user=$(echo "$ssh_out" | sed -n 's/^Hi \([^!]*\)!.*/\1/p')
-  check_pass "SSH auth to github.com works (as: $gh_user)"
+  if [[ "$accepted_fp" == "$LOCAL_FP" ]]; then
+    check_pass "SSH auth to github.com works with this key (as: $gh_user)"
+  else
+    check_fail "SSH auth succeeded but with the WRONG key" \
+      "server accepted ${accepted_fp:-<unknown>}, expected this key $LOCAL_FP -- check ~/.ssh/config IdentityFile leakage"
+  fi
 else
-  check_fail "SSH auth to github.com failed" "$(echo "$ssh_out" | head -3)"
+  check_fail "SSH auth to github.com failed" \
+    "$(echo "$ssh_out" | grep -iE 'denied|permission|error|fatal' | head -3)"
+fi
+
+# --- 8. Per-org SAML SSO authorization (work role only) ---
+# Authenticating to github.com (step 7) only proves the key maps to the
+# account. Org-owned repos behind SAML SSO additionally require the key to be
+# *authorized for that org* -- a separate, per-org, browser-only grant
+# (github.com/settings/keys -> Configure SSO). It is invisible to `ssh -T` and
+# not exposed via gh/API, so the only way to verify it is to actually reach an
+# org repo. An unauthorized key gets a loud "enabled or enforced SAML SSO"
+# error from `git ls-remote` while still passing step 7.
+#
+# Only the work role has org-scoped access. The personal/home role uses a
+# personal identity against personal repos with no org SSO, so it has no org
+# list and this whole block is skipped for it.
+declare -a SSO_ORG_PROBES
+case "$ROLE" in
+  work)
+    # org:probe-repo -- any stable private repo in the org works as a canary.
+    SSO_ORG_PROBES=("Gusto:Gusto/web" "guideline-app:guideline-app/bamboo-cli")
+    ;;
+  *)
+    SSO_ORG_PROBES=()
+    ;;
+esac
+
+if [[ ${#SSO_ORG_PROBES[@]} -gt 0 ]]; then
+  info "Checking per-org SAML SSO authorization (this may take a few seconds)..."
+  # Mirror the live agent sshCommand: -F /dev/null so ~/.ssh/config's additive
+  # `Host *` IdentityFile can't leak the human laptop key into the probe.
+  agent_ssh="ssh -F /dev/null -i $KEY_PATH -o IdentitiesOnly=yes -o IdentityAgent=SSH_AUTH_SOCK -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"
+  for probe in "${SSO_ORG_PROBES[@]}"; do
+    org="${probe%%:*}"
+    repo="${probe#*:}"
+    ls_out=$(GIT_SSH_COMMAND="$agent_ssh" git ls-remote "git@github.com:${repo}.git" HEAD 2>&1 || true)
+    if echo "$ls_out" | grep -q "enabled or enforced SAML SSO"; then
+      check_fail "$org: key not authorized for SAML SSO" \
+        "Authorize at https://github.com/settings/keys -> Configure SSO -> $org"
+    elif echo "$ls_out" | grep -Eq "^[0-9a-f]{40}[[:space:]]+HEAD"; then
+      check_pass "$org: key authorized for SAML SSO (probed $repo)"
+    else
+      check_fail "$org: SSO probe inconclusive (could not reach $repo)" \
+        "$(echo "$ls_out" | head -2)"
+    fi
+  done
 fi
 
 # --- Summary ---

--- a/bin/setup-agent-ssh-key
+++ b/bin/setup-agent-ssh-key
@@ -141,7 +141,8 @@ echo
 echo -e "  ${BOLD}3.${NC} Upload the ${BOLD}same${NC} public key as a ${BOLD}signing key${NC}:"
 echo "     https://github.com/settings/ssh/new (Key type: Signing Key)"
 echo
-echo -e "  ${BOLD}4.${NC} Re-run ${GREEN}./claudeconfig.sh${NC} so role env vars land in ~/.claude/settings.json"
+echo -e "  ${BOLD}4.${NC} Re-run ${GREEN}./claudeconfig.sh --skip-ssh-check${NC} so role env vars land in"
+echo "     ~/.claude/settings.json (--skip-ssh-check because the key isn't authorized yet)"
 echo
 echo -e "  ${BOLD}5.${NC} Start a Claude session under ${GREEN}DOTPICKLES_ROLE=$ROLE${NC}, make a"
 echo "     signed commit, push, and confirm the Verified badge on github.com"

--- a/bin/setup-agent-ssh-key
+++ b/bin/setup-agent-ssh-key
@@ -146,6 +146,18 @@ echo
 echo -e "  ${BOLD}5.${NC} Start a Claude session under ${GREEN}DOTPICKLES_ROLE=$ROLE${NC}, make a"
 echo "     signed commit, push, and confirm the Verified badge on github.com"
 echo
+if [ "$ROLE" = "work" ]; then
+  echo -e "  ${BOLD}6.${NC} ${BOLD}Authorize the key for each org's SAML SSO.${NC} Org-owned repos reject"
+  echo "     an un-authorized key even though plain github.com auth succeeds:"
+  echo -e "     ${GREEN}https://github.com/settings/keys${NC} -> Configure SSO -> Authorize each org"
+  echo
+  echo -e "  ${BOLD}7.${NC} Verify the whole setup (files, Keychain, GitHub registration, SSO):"
+  echo -e "     ${GREEN}bin/check-agent-ssh-key $ROLE --email $EMAIL${NC}"
+else
+  echo -e "  ${BOLD}6.${NC} Verify the whole setup (files, Keychain, GitHub registration):"
+  echo -e "     ${GREEN}bin/check-agent-ssh-key $ROLE --email $EMAIL${NC}"
+fi
+echo
 echo -e "${BOLD}Public key to paste in steps 2 and 3:${NC}"
 echo
 cat "$PUB_PATH"

--- a/claudeconfig.sh
+++ b/claudeconfig.sh
@@ -15,6 +15,34 @@ if ! command_available jq; then
   exit 1
 fi
 
+# Args. SKIP_SSH_CHECK (flag or env) skips only the final agent SSH key
+# validation, leaving config apply intact -- for offline runs and fresh setup,
+# where the key isn't registered/SSO-authorized on GitHub yet.
+SKIP_SSH_CHECK="${SKIP_SSH_CHECK:-}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skip-ssh-check)
+      SKIP_SSH_CHECK=1
+      shift
+      ;;
+    -h | --help)
+      echo "Usage: claudeconfig.sh [--skip-ssh-check]"
+      echo
+      echo "Applies Claude config for \$DOTPICKLES_ROLE (settings.json, marketplaces,"
+      echo "symlinks), then validates the active role's agent SSH key (fail-loud)."
+      echo
+      echo "  --skip-ssh-check  apply config but skip agent SSH key validation"
+      echo "                    (also: SKIP_SSH_CHECK=1). Use offline or mid-setup."
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown argument: $1" >&2
+      echo "Run 'claudeconfig.sh --help' for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
 # Read a JSON or JSONC file, stripping comments and trailing commas
 # Uses node if available for robust JSONC parsing, falls back to sed
 read_json() {
@@ -334,6 +362,45 @@ configure_marketplaces() {
 }
 
 configure_marketplaces
+
+# Validate the active role's agent SSH identity (fail loud). Apply has already
+# completed above, so this only affects the exit code -- config is never left
+# half-written. Delegates to bin/check-agent-ssh-key, which validates local key
+# files, Keychain, GitHub registration, live SSH auth, and (work role) per-org
+# SAML SSO. The agent email is read from the role's gitconfig include so there's
+# one source of truth. Skipped when the role has no agent identity, or when
+# --skip-ssh-check / SKIP_SSH_CHECK=1 is set.
+validate_agent_ssh_key() {
+  echo "Validating agent SSH key..."
+
+  if [ -n "$SKIP_SSH_CHECK" ]; then
+    echo "  ⏭  skipped (--skip-ssh-check)"
+    return 0
+  fi
+
+  local agent_include="$DIR/home/.gitconfig.d/claude-agent-$ROLE"
+  if [ ! -f "$agent_include" ]; then
+    echo "  ⏭  role '$ROLE' has no agent identity ($agent_include); nothing to validate"
+    return 0
+  fi
+
+  local agent_email
+  agent_email=$(git config --file "$agent_include" user.email 2> /dev/null || true)
+  if [ -z "$agent_email" ]; then
+    echo "  ✗ $agent_include has no user.email; cannot determine the agent identity to validate" >&2
+    exit 1
+  fi
+
+  echo "  Role '$ROLE' agent identity: $agent_email"
+  if ! "$DIR/bin/check-agent-ssh-key" "$ROLE" --email "$agent_email"; then
+    echo >&2
+    echo "✗ Agent SSH key validation failed (see above)." >&2
+    echo "  Fix the reported issue, or re-run with --skip-ssh-check to apply without validating." >&2
+    exit 1
+  fi
+}
+
+validate_agent_ssh_key
 
 echo ""
 echo "✓ Claude Code configuration complete"

--- a/doc/adr/0031-role-scoped-agent-git-identity.md
+++ b/doc/adr/0031-role-scoped-agent-git-identity.md
@@ -142,7 +142,7 @@ Three subtleties worth noting:
   holds the unlocked agent key; the literal string `SSH_AUTH_SOCK` is
   specially recognized by ssh and resolved to the env variable's value.
   But `Host *` in `~/.ssh/config` also sets `IdentityFile ~/.ssh/id_ed25519`
-  (the human laptop key), and `IdentityFile` is *additive* — `IdentitiesOnly=yes`
+  (the human laptop key), and `IdentityFile` is _additive_ — `IdentitiesOnly=yes`
   does not drop it, so the laptop key stayed a second candidate identity.
   That caused agent git ops to authenticate to GitHub as the human, or to
   hard-fail headless when the agent couldn't sign the laptop key

--- a/doc/adr/0037-validate-agent-ssh-identity-in-claudeconfig.md
+++ b/doc/adr/0037-validate-agent-ssh-identity-in-claudeconfig.md
@@ -1,0 +1,109 @@
+# 37. Validate the agent SSH identity in claudeconfig
+
+Date: 2026-06-15
+
+## Status
+
+Accepted
+
+Builds on [ADR 0031](0031-role-scoped-agent-git-identity.md) (role-scoped agent
+git identity) and [ADR 0036](0036-fail-loud-role-resolution.md) (fail-loud role
+resolution).
+
+## Context
+
+`bin/check-agent-ssh-key` validates that an agent SSH identity is set up
+correctly: local key files, Keychain, GitHub registration, Claude settings
+wiring, and live SSH auth. But nothing ever forced it to run. It was a manual
+command you remembered to invoke, which means in practice you didn't, and the
+identity drifted out from under you silently.
+
+Two failure modes recently proved how silent this gets:
+
+1. **The auth check passed via the wrong key.** Step 7's `ssh -T github.com` lacked
+   `-F /dev/null`, so `~/.ssh/config`'s additive `Host *` `IdentityFile` left the
+   human laptop key as a candidate (`IdentitiesOnly=yes` does not drop
+   config-supplied identities, only extra agent-offered ones). ssh offered the
+   laptop key first and the server accepted it. Because both keys live on the same
+   GitHub account, the `Hi <user>!` greeting was identical, so the check went green
+   while never exercising the agent key. It would pass even for a broken or
+   unregistered agent key. This is the same leak [ADR 0031](0031-role-scoped-agent-git-identity.md)'s
+   live `sshCommand` fix already addressed; the verifier hadn't caught up.
+
+2. **The key authenticated but was not authorized for an org's SAML SSO.** A key
+   can authenticate to github.com yet still be rejected for org-owned repos until
+   it is explicitly authorized for that org (a separate, per-org, browser-only
+   grant, not exposed via `gh` or the API). The work agent key was authorized for
+   one org but not another; every existing check passed, and the only symptom was
+   agent git operations failing against the unauthorized org at runtime.
+
+`claudeconfig.sh` already generates the role's `GIT_CONFIG_GLOBAL`, which is where
+the agent git identity is wired in per [ADR 0031](0031-role-scoped-agent-git-identity.md).
+It is the natural place to also confirm the identity it just wired actually works
+end to end, instead of leaving that to a command nobody runs.
+
+## Decision
+
+After its apply phases, `claudeconfig.sh` validates the active role's agent SSH
+identity by delegating to `bin/check-agent-ssh-key`, and **fails loud** (exits
+non-zero) if validation fails. Specifics:
+
+- The agent email is read from the role's gitconfig include
+  (`home/.gitconfig.d/claude-agent-$ROLE` `user.email`), so there is one source of
+  truth and no per-role email mapping to drift.
+- Apply runs first, so a validation failure never leaves config half-written; only
+  the exit code reflects validation.
+- Roles with no agent include (e.g. `base`) are a no-op.
+- `bin/check-agent-ssh-key` was hardened to make validation trustworthy: step 7
+  now forces `-F /dev/null` and asserts the fingerprint the server accepted equals
+  this key's, and a per-org SAML SSO probe was added (work role only) that
+  `git ls-remote`s a canary repo per org and detects the "enabled or enforced SAML
+  SSO" rejection.
+
+### Escape hatch
+
+`--skip-ssh-check` (or `SKIP_SSH_CHECK=1`) skips only the validation, leaving apply
+intact. This exists because the validation depends on external state that is not
+always reachable or ready:
+
+- On a fresh machine, `claudeconfig.sh` runs before the key has been registered and
+  SSO-authorized on GitHub. `bin/setup-agent-ssh-key` step 4 uses `--skip-ssh-check`
+  for exactly this reason.
+- Offline, the network and `gh` checks cannot run.
+
+### Why hard-fail here when ADR 0036 chose warn-not-fail
+
+[ADR 0036](0036-fail-loud-role-resolution.md) deliberately warns rather than
+exits for a missing role file, because a missing role file degrades to a still-usable
+`settings.json` generated from base plus stacks: a local, recoverable condition.
+
+A broken agent identity is different in kind. It is external state (GitHub key
+registration, the per-org SSO grant) that the user has to go fix, and when it is
+wrong, agent git operations fail later in confusing ways far from the cause. That is
+precisely the silent-failure class ADR 0036 set out to kill. Surfacing it as a
+warning would get scrolled past and reproduce the same weeks-later mystery. The
+hard-fail makes it un-ignorable; the `--skip-ssh-check` escape hatch preserves the
+recoverable path for the legitimate cases (offline, mid-setup) without weakening the
+default.
+
+## Consequences
+
+### Positive
+
+- The agent identity `claudeconfig.sh` wires is confirmed working at config time,
+  not discovered broken mid-session.
+- Both failure modes above (wrong-key false pass, missing SSO authorization) can no
+  longer ride along silently.
+- SSO authorization, a manual browser-only step that is easy to forget, is now
+  enforced for the work role on every validated run.
+
+### Negative
+
+- Couples a previously offline, deterministic config apply to network reachability,
+  `gh` authentication, and GitHub-side state by default. The validation needs `gh`
+  token scopes (`user:email`, `read:public_key`, `read:ssh_signing_key`) and adds
+  a few seconds of network round-trips to a validated run.
+- Fresh-machine setup and offline runs must pass `--skip-ssh-check`. The guard makes
+  the right path obvious, but it is one more thing to know.
+- Only `claudeconfig.sh` enforces this. Other role-keyed setup steps still have
+  their own behavior and are not unified under one validation mechanism.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -36,3 +36,4 @@
 - [34. local-ssh-allowed-signers-for-commit-verification](0034-local-ssh-allowed-signers-for-commit-verification.md)
 - [35. canonical-dotpickles-role-names](0035-canonical-dotpickles-role-names.md)
 - [36. fail-loud-role-resolution](0036-fail-loud-role-resolution.md)
+- [37. validate-agent-ssh-identity-in-claudeconfig](0037-validate-agent-ssh-identity-in-claudeconfig.md)


### PR DESCRIPTION
## Summary

- `check-agent-ssh-key`'s SSH auth check was a false pass: without `-F /dev/null` it authenticated via the human laptop key (same GitHub account, so the `Hi <user>\!` greeting was identical) and would have green-lit a broken or unregistered agent key. Now it forces the agent key and asserts the accepted fingerprint matches.
- Added a per-org SAML SSO probe (work role): a key can authenticate to github.com yet still be rejected for org repos until authorized for that org's SSO. This caught the agent key being authorized for one org but not another.
- `claudeconfig.sh` now validates the active role's agent SSH identity after applying config, fail-loud, with `--skip-ssh-check` for offline / fresh-setup. Rationale and the contrast with ADR 0036's warn-not-fail are in ADR 0037.
- `setup-agent-ssh-key` now spells out the SSO-authorization step (the bit that's easy to forget) and points at the verifier instead of a manual badge check.

## Test plan

- `bin/check-agent-ssh-key work --email josh.nichols+agent@gusto.com` reports both orgs SSO-authorized and "works with this key".
- `ssh -v` confirmed: with `-F /dev/null` the server accepts the agent key; without it, the laptop key.
- `claudeconfig.sh --help`, bad-arg (exit 2), email derivation, base no-op, and `--skip-ssh-check` early-return all verified. Full apply not run here (it rewrites live `~/.claude/settings.json`).

## Note

With validation live, your next `claudeconfig.sh` (work role) fails until `gh auth refresh -h github.com -s user:email`, the real gap the check flags today. That's fail-loud working as intended; `--skip-ssh-check` bypasses it.
