### PR TITLE
docs: fix stale references in CLAUDE.md files

### DIFF
--- a/.beans/dotfiles-5886--fix-stale-references-in-claudemd-files.md
+++ b/.beans/dotfiles-5886--fix-stale-references-in-claudemd-files.md
@@ -1,0 +1,14 @@
+---
+# dotfiles-5886
+title: Fix stale references in CLAUDE.md files
+status: completed
+type: task
+priority: normal
+created_at: 2026-07-01T14:40:01Z
+updated_at: 2026-07-01T14:40:15Z
+---
+
+Audit found 3 accuracy bugs across CLAUDE.md files:
+- Root CLAUDE.md: subsystem link points to claude/CLAUDE.md (personal instructions) instead of claude/README.md (settings/permissions docs)
+- config/fish/CLAUDE.md: references non-existent atuin.fish; mise listed under conf.d but inits in config.fish
+- bin/CLAUDE.md: missing several Claude utilities (claude-status-line, claude-permissions, claude-with, analyze-claude-sessions)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Common glyphs in this repo: (U+E0B6), (U+E0B4), (U+E0B0), (U+E0B2)
 
 - [doc/architecture.md](doc/architecture.md) -- role system, git config, symlinks, SSH, shell env
 - [doc/spotlight-exclusions.md](doc/spotlight-exclusions.md) -- Spotlight exclusion management
-- [claude/CLAUDE.md](claude/CLAUDE.md) -- Claude Code settings and permissions
+- [claude/README.md](claude/README.md) -- Claude Code settings and permissions (roles + stacks merging)
 - [ssh/CLAUDE.md](ssh/CLAUDE.md) -- SSH config fragments and per-host TERM overrides
 - [bin/CLAUDE.md](bin/CLAUDE.md) -- custom binaries and spotlight scripts
 - [config/fish/CLAUDE.md](config/fish/CLAUDE.md) -- fish shell config structure

--- a/bin/CLAUDE.md
+++ b/bin/CLAUDE.md
@@ -23,6 +23,10 @@ Spotlight is kept enabled (Alfred requires it) but specific directories are excl
 ## Claude Code Utilities
 
 - `bin/claude-spend-today`: Read today's Claude spend from ccusage cache (for tmux status bar)
+- `bin/claude-status-line`: Status line wrapper (fixes Opus context window size, formats model name, wraps claude-powerline with capsule style)
+- `bin/claude-permissions`: Query Claude Code permissions across all known config locations
+- `bin/claude-with`: Run Claude with a named environment (isolated `CLAUDE_CONFIG_DIR` per env under `~/.local/share/claude-env/<name>/`)
+- `bin/analyze-claude-sessions`: Analyze Claude Code sessions (via cq) to identify projects and skill usage
 - `bin/ccusage-refresh`: Refresh ccusage cache (run by LaunchAgent every 5 min)
 - `bin/tmux-smart-open`: Open URLs/files on double-click in tmux
 - `bin/tmux-auto-rename-session`: Auto-name sessions after their directory

--- a/config/fish/CLAUDE.md
+++ b/config/fish/CLAUDE.md
@@ -13,8 +13,7 @@ Fish is the primary shell. Config is modular via `conf.d/` autoloading.
 - `editor.fish`: Sets `EDITOR` based on `envsense` environment detection (Cursor vs Claude Code vs terminal)
 - `ghostty.fish`: Ghostty-specific setup
 - `cursor_agent.fish`, `obsidian.fish`: IDE-specific behaviors
-- `atuin.fish`: Shell history with atuin
-- Tool inits: starship, homebrew, bat, git-duet, mise, etc.
+- Tool inits: starship, homebrew, bat, git-duet, pyenv, rustup, uv, zoxide, etc. (mise inits in `config.fish`, not conf.d)
 
 ## Load Order Gotcha
 


### PR DESCRIPTION
Found via `/claude-md-improver` audit (dotfiles-5886). Three accuracy bugs across CLAUDE.md files:

- **root `CLAUDE.md`**: subsystem link pointed to `claude/CLAUDE.md` (the personal-instructions template) instead of `claude/README.md` (the actual roles + stacks settings/permissions docs).
- **`config/fish/CLAUDE.md`**: referenced a non-existent `atuin.fish`; `mise` was listed under conf.d tool-inits but it actually inits in `config.fish`.
- **`bin/CLAUDE.md`**: documented `claude-status-line`, `claude-permissions`, `claude-with`, and `analyze-claude-sessions` (descriptions pulled from each script's header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)