### PR TITLE
fix(claude): add missing sandbox allowWrite paths for obsidian vault + superpowers-chrome

### DIFF
--- a/.beans/dotfiles-7m1a--fix-sandbox-allowwrite-gaps-for-pickled-knowledge.md
+++ b/.beans/dotfiles-7m1a--fix-sandbox-allowwrite-gaps-for-pickled-knowledge.md
@@ -1,0 +1,22 @@
+---
+# dotfiles-7m1a
+title: Fix sandbox allowWrite gaps for pickled-knowledge vault and superpowers-chrome cache
+status: in-progress
+type: bug
+priority: normal
+created_at: 2026-07-09T20:02:45Z
+updated_at: 2026-07-09T20:04:54Z
+---
+
+Found via cq query of the last week's Claude Code session transcripts: 13 sandbox EPERM failures, two of which are genuine allowlist gaps.
+
+1. sb note create EPERM on ~/Vaults/pickled-knowledge (hit 4x across pickleton/groot/claude-code sessions). claude/stacks/obsidian.jsonc's sandbox.filesystem.allowWrite only had ~/.cache/qmd/ -- the vault write path itself was never added. Its permissions.allow also still pointed at the old /Users/technicalpickles/Documents/pickled-knowledge path from a previous machine/username, which doesn't exist on this machine at all.
+
+2. superpowers-chrome mkdir EPERM on ~/.cache/superpowers/browser-profiles/superpowers-chrome. claude/stacks/skills.jsonc only had a Read permission for ~/Library/Caches/superpowers/** (macOS-style path). Checked the plugin source (chrome-launcher-helpers.js, getXdgCacheHome()) -- it actually always uses the XDG ~/.cache/superpowers path, so the Library/Caches entry didn't correspond to anything the plugin writes.
+
+## Checklist
+- [x] obsidian.jsonc: add ~/Vaults/pickled-knowledge to sandbox.filesystem.allowWrite
+- [x] obsidian.jsonc: fix stale technicalpickles permissions.allow paths to ~/Vaults/pickled-knowledge
+- [x] skills.jsonc: add ~/.cache/superpowers to sandbox.filesystem.allowWrite (and fix the stale Read path)
+- [x] regenerate settings.json via claudeconfig.sh and verify the two paths land
+- [x] npm run lint (prettier clean on both files; pre-existing unrelated tsconfig deprecation warning confirmed via git stash)

--- a/.beans/dotfiles-7m1a--fix-sandbox-allowwrite-gaps-for-pickled-knowledge.md
+++ b/.beans/dotfiles-7m1a--fix-sandbox-allowwrite-gaps-for-pickled-knowledge.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-7m1a
 title: Fix sandbox allowWrite gaps for pickled-knowledge vault and superpowers-chrome cache
-status: in-progress
+status: completed
 type: bug
 priority: normal
 created_at: 2026-07-09T20:02:45Z
-updated_at: 2026-07-09T20:04:54Z
+updated_at: 2026-07-09T20:05:01Z
 ---
 
 Found via cq query of the last week's Claude Code session transcripts: 13 sandbox EPERM failures, two of which are genuine allowlist gaps.

--- a/claude/stacks/obsidian.jsonc
+++ b/claude/stacks/obsidian.jsonc
@@ -3,15 +3,17 @@
     "allow": [
       "Skill(second-brain:distill-conversation)",
       "Read(~/.claude/second-brain.md)",
-      "Read(/Users/technicalpickles/Documents/pickled-knowledge/**/*.md)",
-      "Write(/Users/technicalpickles/Documents/pickled-knowledge/**/*.md)",
-      "Edit(/Users/technicalpickles/Documents/pickled-knowledge/**/*.md)",
+      "Read(~/Vaults/pickled-knowledge/**/*.md)",
+      "Write(~/Vaults/pickled-knowledge/**/*.md)",
+      "Edit(~/Vaults/pickled-knowledge/**/*.md)",
     ],
   },
 
   "sandbox": {
     "filesystem": {
-      "allowWrite": ["~/.cache/qmd/"],
+      // ~/Vaults/pickled-knowledge is the Obsidian vault itself; sb note
+      // create (@techpickles/sb) writes new notes directly into its inbox.
+      "allowWrite": ["~/.cache/qmd/", "~/Vaults/pickled-knowledge"],
     },
   },
 }

--- a/claude/stacks/skills.jsonc
+++ b/claude/stacks/skills.jsonc
@@ -5,8 +5,10 @@
       // Plugin cache read access (reduces per-skill permission prompts)
       "Read(~/.claude/plugins/cache/**)",
       "Read(~/.claude/plugins/marketplaces/pickled-claude-plugins)",
-      // superpowers-chrome puts stuff here
-      "Read(~/Library/Caches/superpowers/**)",
+      // superpowers-chrome browser profiles/sessions. Always XDG ~/.cache
+      // even on macOS (see chrome-launcher-helpers.js getXdgCacheHome()) --
+      // not the ~/Library/Caches path this used to point at.
+      "Read(~/.cache/superpowers/**)",
       "Skill(buildkite-status)",
       "Skill(checkout-pr)",
       "Skill(ci-cd-tools:buildkite-status)",
@@ -32,5 +34,12 @@
       "Skill(working-in-monorepos:working-in-monorepos)",
       "Skill(working-in-scratch-areas)",
     ],
+  },
+
+  "sandbox": {
+    "filesystem": {
+      // superpowers-chrome creates its browser-profiles dir on first launch.
+      "allowWrite": ["~/.cache/superpowers"],
+    },
   },
 }


### PR DESCRIPTION
## Summary
- `sb note create` was EPERM'ing on `~/Vaults/pickled-knowledge` (4x this week per a cq scan of session transcripts). `obsidian.jsonc`'s `sandbox.filesystem.allowWrite` only had `~/.cache/qmd/`, never the vault itself. Its `permissions.allow` also still pointed at the old `technicalpickles` path from a previous machine, fixed to `~/Vaults/pickled-knowledge`.
- `superpowers-chrome`'s browser-profiles mkdir was EPERM'ing on `~/.cache/superpowers`. `skills.jsonc` only had a `Read` rule for `~/Library/Caches/superpowers`, a macOS-style path the plugin never actually uses (confirmed via `getXdgCacheHome()` in the plugin source, it's always XDG `~/.cache`).

## Test plan
- [x] `npx prettier --check` on both changed files
- [x] `npm run typecheck` confirmed the one failing check is a pre-existing, unrelated tsconfig deprecation warning (reproduced via `git stash`)
- [x] Ran `claudeconfig.sh --skip-ssh-check` and confirmed the regenerated `~/.claude/settings.json` contains `~/.cache/superpowers` and `~/Vaults/pickled-knowledge` in `sandbox.filesystem.allowWrite`, the stale `technicalpickles` permission entries are gone, and `enabledPlugins`/`extraKnownMarketplaces` survived the regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)