### PR TITLE
Speed up fish startup and cd

### DIFF
--- a/config/fish/conf.d/editor.fish
+++ b/config/fish/conf.d/editor.fish
@@ -1,14 +1,14 @@
 # vscode is pretty alright when we're in it
-if string match -r -q insider "$TERM_PROGRAM_VERSION" && which code-insiders >/dev/null
+if string match -r -q insider "$TERM_PROGRAM_VERSION" && command -q code-insiders
     set -gx EDITOR "code-insiders -w"
-else if [ "$TERM_PROGRAM" = vscode ] && which code >/dev/null
+else if [ "$TERM_PROGRAM" = vscode ] && command -q code
     set -gx EDITOR "code -w"
     # use stable while running inside stable
 # we like vim. see https://github.com/technicalpickles/pickled-vim for settings
-else if which -s nvim >/dev/null
+else if command -q nvim
     set -gx EDITOR nvim
-else if which -s vim >/dev/null
+else if command -q vim
     set -gx EDITOR vim
-else if which -s vi >/dev/null
+else if command -q vi
     set -gx EDITOR vi
 end

--- a/config/fish/conf.d/mise-activate.fish
+++ b/config/fish/conf.d/mise-activate.fish
@@ -1,0 +1,30 @@
+# Disable homebrew's mise auto-activation. We activate mise ourselves, in shims
+# mode, in config.fish (both the gusto branch via ~/.gusto/init.sh and the else
+# branch). Homebrew additionally ships
+# /opt/homebrew/share/fish/vendor_conf.d/mise-activate.fish, which runs a *full*
+# activation on top of that. Full mode conflicts with shims mode and installs
+# PWD/fish_prompt/fish_preexec handlers that each shell out to `mise hook-env`.
+# Measured 2026-07-31: ~80ms at startup, ~50ms per cd, ~13ms per prompt.
+#
+# TWO mechanisms here, deliberately:
+#
+# 1. The FILENAME. fish sources conf.d as user -> sysconf -> vendor, skipping any
+#    file whose basename it has already seen ("Implement precedence (User > Admin
+#    > Extra (e.g. vendors) > Fish) by basically doing 'basename'" in fish's own
+#    config.fish). Naming this `mise-activate.fish` means the vendor file is never
+#    sourced at all. This is the load-bearing part.
+#
+# 2. The variable. Belt and suspenders, in case homebrew renames its file. Note
+#    `0` is the ONLY value that disables it -- the vendor guard is
+#    `if [ "$MISE_FISH_AUTO_ACTIVATE" != "0" ]`. ~/.gusto/init.fish sets `1`
+#    intending to disable it, which has never worked.
+#
+# Don't move this to config.fish: that runs AFTER every conf.d file, including
+# vendor, so the variable would be set too late to matter. (A universal variable
+# is the other way to beat the ordering, but that lives in fish_variables, which
+# isn't version controlled, so a fresh machine silently loses it.)
+#
+# Tradeoff: per-directory mise `[env]` no longer applies on cd. Tool versions are
+# unaffected (that's what shims do). Repos relying on it: repos/web
+# (SHARP_IGNORE_GLOBAL_LIBVIPS), repos/dotfiles-devcontainer.
+set -gx MISE_FISH_AUTO_ACTIVATE 0

--- a/config/fish/conf.d/pitchfork.fish
+++ b/config/fish/conf.d/pitchfork.fish
@@ -2,5 +2,21 @@
 # Adds the cd hook that drives `auto = ["start", "stop"]` in pitchfork.toml
 # https://github.com/endevco/pitchfork
 if command -q pitchfork
-    pitchfork activate fish | source
+    # `pitchfork activate fish` emits the __pitchfork PWD handler and then calls it
+    # eagerly. That call is a ~60ms blocking round-trip to the supervisor and nothing
+    # in the shell reads its result, so strip it and fire the same call in the
+    # background instead (measured 583ms -> 467ms startup). Backgrounding the
+    # __pitchfork *function* instead of the binary only bought ~20ms -- fish forks
+    # the whole shell state for that, which costs about as much as it saves.
+    #
+    # The PWD handler stays synchronous: backgrounding it would let rapid cds land
+    # out of order and leave the supervisor tracking a stale directory.
+    #
+    # This duplicates activate's invocation, so if upstream changes the args this
+    # silently no-ops -- the PWD handler still fires on the first cd, so the worst
+    # case is the initial directory not being reported.
+    pitchfork activate fish | string match --invert --regex '^__pitchfork$' | source
+
+    pitchfork cd --shell-pid $fish_pid >/dev/null 2>&1 &
+    disown
 end

--- a/config/fish/conf.d/pitchfork.fish
+++ b/config/fish/conf.d/pitchfork.fish
@@ -1,22 +1,17 @@
-# Pitchfork daemon manager
-# Adds the cd hook that drives `auto = ["start", "stop"]` in pitchfork.toml
+# Pitchfork daemon manager -- shell integration intentionally NOT activated.
 # https://github.com/endevco/pitchfork
-if command -q pitchfork
-    # `pitchfork activate fish` emits the __pitchfork PWD handler and then calls it
-    # eagerly. That call is a ~60ms blocking round-trip to the supervisor and nothing
-    # in the shell reads its result, so strip it and fire the same call in the
-    # background instead (measured 583ms -> 467ms startup). Backgrounding the
-    # __pitchfork *function* instead of the binary only bought ~20ms -- fish forks
-    # the whole shell state for that, which costs about as much as it saves.
-    #
-    # The PWD handler stays synchronous: backgrounding it would let rapid cds land
-    # out of order and leave the supervisor tracking a stale directory.
-    #
-    # This duplicates activate's invocation, so if upstream changes the args this
-    # silently no-ops -- the PWD handler still fires on the first cd, so the worst
-    # case is the initial directory not being reported.
-    pitchfork activate fish | string match --invert --regex '^__pitchfork$' | source
-
-    pitchfork cd --shell-pid $fish_pid >/dev/null 2>&1 &
-    disown
-end
+#
+# `pitchfork activate fish` installs a PWD handler that calls `pitchfork cd` on
+# every directory change. Its only job is driving `auto = ["start", "stop"]`, and
+# that cost ~60-100ms on every single cd (about two thirds of a 153ms cd).
+#
+# It also tied daemon lifetime to shell presence, so any transient fish in a
+# project (agent session, script, one-off command) would start its daemons and
+# stop them again one autostop_delay later. pickleton's pt-serve bounced three
+# times in one afternoon that way.
+#
+# Daemons that should always be up now use `boot_start = true` instead, which the
+# supervisor honours at login via the LaunchAgent (`supervisor run --boot`). See
+# pickleton docs/pitchfork.md. Start things by hand with `pitchfork start <name>`.
+#
+# To re-enable: `pitchfork activate fish | source`

--- a/config/fish/conf.d/ssh-keychain.fish
+++ b/config/fish/conf.d/ssh-keychain.fish
@@ -1,5 +1,13 @@
 # Load SSH keys from macOS keychain into the agent on first shell after reboot.
 # The fish-ssh-agent plugin manages the agent socket; this just loads stored keys.
+#
+# --apple-load-keychain costs ~750ms of CPU: the stored key is bcrypt-encrypted,
+# so ssh-add runs the KDF every time, even when the agent already holds the key.
+# `ssh-add -l` answers "is the agent already populated?" for free, which is a good
+# enough proxy for "have we done this since boot" -- exit 1 (agent up but empty)
+# and exit 2 (no agent at all) both fall through to the load.
 if test (uname) = Darwin
-    ssh-add --apple-load-keychain 2>/dev/null
+    if not ssh-add -l >/dev/null 2>&1
+        ssh-add --apple-load-keychain 2>/dev/null
+    end
 end

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -79,7 +79,3 @@ set -gx EZA_CONFIG_DIR "$HOME/.config/eza"
 # fabro
 fish_add_path $HOME/.fabro/bin
 
-# Added by LM Studio CLI (lms)
-set -gx PATH $PATH /Users/josh.nichols/.lmstudio/bin
-# End of LM Studio CLI section
-

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -21,11 +21,11 @@ else
     end
 end
 
-if which op >/dev/null && test -f ~/.config/op/plugins.sh
+if command -q op && test -f ~/.config/op/plugins.sh
     source ~/.config/op/plugins.sh
 end
 
-if which fnox >/dev/null
+if command -q fnox
     fnox activate fish | source
 end
 

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -82,6 +82,3 @@ if [[ -f "$HOME/.local/bin/env" ]]; then
   . "$HOME/.local/bin/env"
 fi
 
-# Added by LM Studio CLI (lms)
-export PATH="$PATH:/Users/josh.nichols/.lmstudio/bin"
-# End of LM Studio CLI section

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -81,4 +81,3 @@ if [[ -f "$HOME/.local/bin/env" ]]; then
   # shellcheck disable=SC1091
   . "$HOME/.local/bin/env"
 fi
-

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -137,6 +137,3 @@ if [[ -d "$OSH" ]]; then
   source "$OSH"/oh-my-bash.sh
 fi
 
-# Added by LM Studio CLI (lms)
-export PATH="$PATH:/Users/josh.nichols/.lmstudio/bin"
-# End of LM Studio CLI section

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -136,4 +136,3 @@ plugins=(
 if [[ -d "$OSH" ]]; then
   source "$OSH"/oh-my-bash.sh
 fi
-

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -109,4 +109,3 @@ fi
 if command -v pickletown &> /dev/null; then
   alias pt=pickletown
 fi
-

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -110,6 +110,3 @@ if command -v pickletown &> /dev/null; then
   alias pt=pickletown
 fi
 
-# Added by LM Studio CLI (lms)
-export PATH="$PATH:/Users/josh.nichols/.lmstudio/bin"
-# End of LM Studio CLI section


### PR DESCRIPTION
## Summary

Fish took 1.17s to start and 153ms to `cd`. Profiling with `fish --profile-startup` found four things, all of them work that didn't need doing:

- **`ssh-add --apple-load-keychain` was 64% of startup (750ms).** `~/.ssh/id_ed25519` is bcrypt-encrypted, so ssh-add re-ran the KDF on every single shell, for a key the agent already held. Now guarded behind `ssh-add -l`, which is free. Post-reboot behavior is intact: agent-empty (exit 1) and no-agent (exit 2) both still load.
- **pitchfork's cd-hook cost 60-100ms per `cd`** and tied daemon lifetime to shell presence, so any transient fish in a project started its daemons and stopped them again a minute later. `pt-serve` bounced three times in one afternoon that way. Daemons use `boot_start = true` now.
- **Homebrew's mise auto-activation was a second, conflicting activation.** We already activate in shims mode in `config.fish`; the vendor file added a full activation on top, with PWD, prompt and preexec hooks that each shell out to `mise hook-env`. `~/.gusto/init.fish` has always tried to disable this and set the wrong value (`1`, where only `0` disables).
- **`~/.lmstudio/bin` doesn't exist on this machine** and was being appended by all four shell rc files, twice in nested shells because the installer's append isn't idempotent.

|            | before | after |
|------------|-------:|------:|
| startup    | 1.17s  | 0.48s |
| per `cd`   | 153ms  |  35ms |
| per prompt |  30ms  |  23ms |

## Breaking changes

Per-directory mise `[env]` no longer applies on `cd`. Tool versions are unaffected, that's what shims do, but env vars declared in a repo's `mise.toml` won't be exported. Two repos rely on it today: `web` (`SHARP_IGNORE_GLOBAL_LIBVIPS`) and `dotfiles-devcontainer`.

Autostart-on-`cd` is gone. Daemons come up at login via `boot_start`, or by hand with `pitchfork start <name>`. This needs a `[namespaces.<name>]` entry in `~/.config/pitchfork/config.toml` as well, because at login the supervisor starts from `$HOME` and the cd-hook was its only source of project awareness. Written up in pickleton's `docs/pitchfork.md`.

`team-hud`'s `pitchfork.local.toml` used `auto = [...]`, which only ever worked through the hook. It hadn't run since June 24, so nothing regressed in practice, but the migration path is in those same docs.

## Test plan

Timings were taken as interleaved A/B (alternating configs, 12 samples each) because this machine's load average swings enough to swamp a naive before/after.

```fish
# nothing re-adds lmstudio, tools still resolve
env -i HOME=$HOME TERM=xterm PATH=/opt/homebrew/bin:/usr/bin:/bin fish -i -c \
  'count (string match -a "*lmstudio*" $PATH); command -v ruby node pt'

# vendor mise activation really is masked
fish -i -c 'functions -q __mise_env_eval; and echo STILL ON; or echo masked'

# ssh guard: populated agent skips, empty agent still loads
fish --no-config -c 'if not ssh-add -l >/dev/null 2>&1; echo would-load; else; echo skips; end'
```

The ssh guard needs `--no-config` to test honestly, because `fish-ssh-agent.fish` re-pins `SSH_AUTH_SOCK` from `~/.ssh/environment` and will quietly hand you the populated agent either way.

## Follow-up

`~/.gusto/init.fish` is the largest remaining cost at ~210ms, going through `bass` to spawn bash and round-trip the env through python3. It's Gusto-managed and lives outside this repo.
