### PR TITLE
Version herdr config with tmux-style keybindings

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -1,0 +1,81 @@
+# herdr - terminal multiplexer / agent orchestrator
+# https://github.com/herdrdev/herdr
+#
+# symlinks.sh links this single file to ~/.config/herdr/config.toml. The
+# directory itself is deliberately NOT symlinked: herdr keeps live sockets,
+# session.json, plugins/, and logs there, and that runtime state has no
+# business in a git working tree.
+#
+# Regenerate a fully commented reference with:  herdr --default-config
+# Reload without restarting:                    prefix+shift+r
+# See every active binding:                     prefix+?
+
+[theme]
+name = "tokyo-night"
+auto_switch = false
+
+[ui]
+show_agent_labels_on_pane_borders = true
+
+# "priority" sorts the agent panel as an attention queue:
+# blocked -> done/unseen -> working -> idle. This also reorders what
+# next_agent/previous_agent walk, which is what makes them useful.
+agent_panel_sort = "priority"
+
+[keys]
+# Match tmux (~/.tmux.conf uses C-Space).
+# Note: if herdr ever runs *inside* tmux, both grab this and you'll be
+# double-pressing. The escape hatch is direct ctrl+alt+* chords.
+prefix = "ctrl+space"
+
+# ---------------------------------------------------------------------------
+# Agent attention cycling
+# ---------------------------------------------------------------------------
+# Unbound by default. Combined with agent_panel_sort = "priority" above,
+# next_agent walks blocked -> done -> working -> idle. From a non-agent pane
+# it lands on the single most-urgent agent.
+#
+# The explicit alternative, already bound: prefix+g opens the session
+# navigator, then bare `b` filters to blocked, `d` to done, `a` clears.
+next_agent = "prefix+a"
+previous_agent = "prefix+shift+a"
+
+# prefix+alt+1 = most urgent agent (with priority sort)
+focus_agent = "prefix+alt+1..9"
+
+# ---------------------------------------------------------------------------
+# tmux / pain-control muscle memory
+# ---------------------------------------------------------------------------
+# herdr's defaults already match tmux for: prefix+h/j/k/l pane focus,
+# prefix+- stacked split, prefix+c new tab, prefix+n/p tab cycle,
+# prefix+[ copy mode, prefix+z zoom, prefix+x close pane, prefix+R reload.
+# These add the aliases pain-control trained into my hands.
+
+# pain-control: | and % split side-by-side, " splits stacked
+split_vertical = ["prefix+v", "prefix+|", "prefix+percent"]
+split_horizontal = ["prefix+minus", "prefix+double_quote"]
+
+# pain-control binds both h and C-h for pane navigation
+focus_pane_left = ["prefix+h", "prefix+ctrl+h"]
+focus_pane_down = ["prefix+j", "prefix+ctrl+j"]
+focus_pane_up = ["prefix+k", "prefix+ctrl+k"]
+focus_pane_right = ["prefix+l", "prefix+ctrl+l"]
+
+# tmux-sensible binds C-p/C-n alongside p/n
+previous_tab = ["prefix+p", "prefix+ctrl+p"]
+next_tab = ["prefix+n", "prefix+ctrl+n"]
+
+# ---------------------------------------------------------------------------
+# Deliberately NOT remapped
+# ---------------------------------------------------------------------------
+# prefix+shift+h/j/k/l  herdr swaps panes here; tmux/pain-control resizes.
+#                       Leaving herdr's default. Resize lives behind
+#                       prefix+r (resize mode). This is the one real
+#                       muscle-memory trap in the migration.
+# prefix+s              herdr = settings; tmux = session chooser.
+#                       prefix+g (goto) is the closer analog.
+#
+# No herdr equivalent exists for: \ and _ (full-width splits),
+# < and > (swap window), prefix+Space (last-window; herdr's last_pane is
+# pane-level only), T/N (sesh + pickletown pickers), C (open Claude Code).
+# The pickers and C could be rebuilt as [[keys.command]] entries.

--- a/functions.sh
+++ b/functions.sh
@@ -62,8 +62,10 @@ find_targets() {
 link_directory_contents() {
   local directory="$1"
   # Items managed by their own installer scripts (e.g. fish.sh handles config/fish,
-  # sshconfig.sh handles config/1password's role-aware agent.toml symlink)
-  local -a skip=(config home config/fish config/1password)
+  # sshconfig.sh handles config/1password's role-aware agent.toml symlink).
+  # config/herdr is file-linked by symlinks.sh: herdr keeps live sockets,
+  # session.json, and logs in ~/.config/herdr, which must not land in the repo.
+  local -a skip=(config home config/fish config/1password config/herdr)
   for linkable in $(find_targets "${directory}"); do
     local should_skip=false
     for s in "${skip[@]}"; do

--- a/symlinks.sh
+++ b/symlinks.sh
@@ -30,6 +30,13 @@ link_directory_contents home
 mkdir -p "$HOME/.config"
 link_directory_contents config
 
+# herdr: link only config.toml, not the directory. herdr keeps live unix
+# sockets, session.json, and logs alongside it in ~/.config/herdr; a directory
+# symlink would put that runtime state in the repo, where `git clean -xfd`
+# would eat the live session.
+mkdir -p "$HOME/.config/herdr"
+link config/herdr/config.toml "$HOME/.config/herdr/config.toml"
+
 # Link LaunchAgents if on macOS
 if running_macos; then
   mkdir -p "$HOME/Library/LaunchAgents"


### PR DESCRIPTION
## Summary

- Starts tracking [herdr](https://github.com/herdrdev/herdr)'s config so the keymap lives with the rest of the dotfiles. Prefix moves to `ctrl+space` to match `.tmux.conf`, plus aliases for the pain-control bindings my hands already know (`|` and `%` for side-by-side splits, `"` for stacked, `ctrl+hjkl` for pane focus).
- Binds `next_agent` / `previous_agent`, which ship unbound, together with `ui.agent_panel_sort = "priority"`. That combination turns the agent panel into an attention queue and makes `prefix+a` cycle blocked, then finished-but-unseen, then working, then idle. It is the closest thing herdr has to "jump to whichever agent needs me."
- Links only `config.toml`, not the `config/herdr` directory. herdr keeps live unix sockets, `session.json`, and its logs in `~/.config/herdr`, so a directory symlink would put churning runtime state in the working tree where `git clean -xfd` would eat the live session. `config/herdr` goes on the `link_directory_contents` skip list and `symlinks.sh` links the single file.

Deliberately left `prefix+shift+hjkl` alone. herdr swaps panes there where tmux resizes, and rebinding it would silently kill swap. Resize lives behind `prefix+r`.

## Heads up

herdr writes back to `config.toml`: toggling the agent panel sort from the sidebar header persists the choice to disk. Expect UI toggles to show up as diffs here, the same way `config/gh/config.yml` does.

## Test plan

- `./symlinks.sh` puts a symlink at `~/.config/herdr/config.toml` and leaves the surrounding directory alone, so a running server keeps its sockets and session. No shutdown needed, and `herdr server reload-config` picks up the new keymap live.
- `herdr config check` reports `config: ok`. Worth knowing it only catches typo'd field names and unparseable bindings. It stays quiet when a user binding steals a key from a herdr default, so the defaults were checked by hand, and it also reports `ok` when the file is missing entirely.
