### PR TITLE
Run typecheck on pre-commit to match CI

### DIFF
--- a/.claude/rules/ci-precommit.md
+++ b/.claude/rules/ci-precommit.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - '.github/workflows/**'
+  - 'lefthook.yml'
+---
+
+# Keeping CI and Pre-Commit in Sync
+
+When adding or changing a CI check, add a matching `lefthook.yml` pre-commit command if the check is fast and cheap (typecheck, lint) -- so failures surface before pushing, not after. Skip it for slow/expensive checks (full test suites, builds) where CI-only is the right tradeoff.
+
+**Why:** CI and `lefthook.yml` are edited independently, so they drift silently -- a check added to one doesn't imply it's mirrored in the other. This bit us once: CI ran `tsc --noEmit` but pre-commit only ran prettier, so type errors reached `main` before being caught (fixed in commit `763ae77`).
+
+**How to apply:** when editing either file, diff the checks each one runs. A check present in CI but missing from pre-commit (or vice versa) is worth a second look, not necessarily a bug -- some checks are deliberately CI-only.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,6 +18,9 @@ pre-commit:
     prettier:
       stage_fixed: true
       run: bin/prettier --write {staged_files}
+    typecheck:
+      glob: '*.ts'
+      run: npm run typecheck
 #     rubocop:
 #       tags: backend style
 #       glob: "*.rb"


### PR DESCRIPTION
## Summary

- Pre-commit only ran prettier, so a TypeScript type error would pass locally and only get caught by CI. Add a `typecheck` command to `lefthook.yml`'s `pre-commit` block, gated to `*.ts` changes, running the same `npm run typecheck` CI already uses.

## Test plan

- `npm run typecheck` passes cleanly on its own.
- Couldn't smoke-test the hook directly since `lefthook` isn't installed in this worktree, but the new command mirrors the existing `prettier` command's shape.
