### PR TITLE
Agent sessions use HTTPS for github.com, sidestepping sandbox SSH block

### DIFF
--- a/.beans/dotfiles-187t--switch-agent-git-transport-to-https-to-sidestep-sa.md
+++ b/.beans/dotfiles-187t--switch-agent-git-transport-to-https-to-sidestep-sa.md
@@ -1,0 +1,23 @@
+---
+# dotfiles-187t
+title: Switch agent git transport to HTTPS to sidestep sandbox SSH block
+status: in-progress
+type: feature
+priority: normal
+created_at: 2026-08-26T18:19:06Z
+updated_at: 2026-08-26T18:21:43Z
+---
+
+Add url.insteadOf + credential.helper to the claude-agent-{work,home} gitconfig fragments so agent git push/fetch/pull over github.com use HTTPS instead of SSH. The Claude Code sandbox denies outbound port 22 at the TCP connect level (confirmed in pickletown bean gt-o2jy), so every SSH-based git op fails sandboxed and needs dangerouslyDisableSandbox as a workaround. HTTPS via gh's credential helper (gh auth git-credential) is already proven to work sandboxed for push+fetch.
+
+Scope: agent-only, via the existing GIT_CONFIG_GLOBAL role-scoped fragments (ADR 0031) — home/.gitconfig.d/claude-agent-work and claude-agent-home. Does not touch the user's normal interactive git config or pt track's SSH default (that's a separate pickletown bean, gt-rv0z, and doesn't need to change).
+
+Known tradeoff, accepted: the only proven HTTPS auth path (gh auth git-credential) uses gh's shared personal OAuth token, not a role-scoped credential. This weakens ADR 0031's 'independently revocable' property for push authorization (though commit signing/attribution stays per-role, since that's local and unaffected). Decided to accept this for now rather than provision per-role PATs.
+
+## Checklist
+- [x] Add [url "https://github.com/"] insteadOf = git@github.com: to claude-agent-work
+- [x] Add [credential "https://github.com"] helper = !gh auth git-credential to claude-agent-work
+- [x] Same two additions to claude-agent-home
+- [x] Verify push+fetch work sandboxed against a real repo using the new config (tested against technicalpickles/dotfiles with a scratch branch, cleaned up)
+- [x] Verify commit signing still works unchanged (confirmed Good signature for josh.nichols+agent@gusto.com)
+- [ ] Update pickleton's .claude/rules/sandbox-git-writes.md to reflect the fix (once merged)

--- a/home/.gitconfig.d/claude-agent-home
+++ b/home/.gitconfig.d/claude-agent-home
@@ -32,3 +32,14 @@
 	format = ssh
 [gpg "ssh"]
 	program = ssh-keygen
+# The Claude Code sandbox denies outbound port 22 at the TCP connect level, so
+# any SSH remote (push/fetch/pull/clone) fails sandboxed regardless of which
+# key or agent would authenticate -- confirmed in pickletown bean gt-o2jy.
+# HTTPS to github.com already works sandboxed (that's the path gh/WebFetch
+# use), so rewrite SSH remotes to HTTPS and hand auth off to gh's credential
+# helper. This only affects agent sessions (this file is only reachable via
+# GIT_CONFIG_GLOBAL) -- your interactive shell keeps using SSH normally.
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+[credential "https://github.com"]
+	helper = !gh auth git-credential

--- a/home/.gitconfig.d/claude-agent-work
+++ b/home/.gitconfig.d/claude-agent-work
@@ -32,3 +32,14 @@
 	format = ssh
 [gpg "ssh"]
 	program = ssh-keygen
+# The Claude Code sandbox denies outbound port 22 at the TCP connect level, so
+# any SSH remote (push/fetch/pull/clone) fails sandboxed regardless of which
+# key or agent would authenticate -- confirmed in pickletown bean gt-o2jy.
+# HTTPS to github.com already works sandboxed (that's the path gh/WebFetch
+# use), so rewrite SSH remotes to HTTPS and hand auth off to gh's credential
+# helper. This only affects agent sessions (this file is only reachable via
+# GIT_CONFIG_GLOBAL) -- your interactive shell keeps using SSH normally.
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+[credential "https://github.com"]
+	helper = !gh auth git-credential


### PR DESCRIPTION
## Summary
- The Claude Code sandbox denies outbound port 22 at the TCP connect level, so agent git push/fetch/pull/clone over SSH fails and needs `dangerouslyDisableSandbox` every time
- Adds `url.insteadOf` (rewrite `git@github.com:` to `https://github.com/`) and a `gh`-backed credential helper to both `claude-agent-work` and `claude-agent-home` (ADR 0031's role-scoped fragments), so agent sessions transparently use HTTPS instead
- Scoped to agent sessions only, via the existing `GIT_CONFIG_GLOBAL` mechanism -- interactive shells are untouched and keep using SSH

## Test plan
- [x] `git ls-remote` via the new config, sandboxed (no override) -- resolved over HTTPS
- [x] `git push`/delete of a scratch branch against `technicalpickles/dotfiles` via the new config, sandboxed -- succeeded, cleaned up
- [x] Commit signing still produces a `Good` signature for the agent identity (signing is local, unaffected by transport)
- [x] This very PR was pushed sandboxed using the pattern this PR introduces

Related: pickletown bean gt-o2jy (the underlying investigation) and dotfiles-187t.