### PR TITLE
sandbox: allow writes to ~/.Trash for the gusto-dev rm-to-trash hook

### DIFF
--- a/claude/roles/base.jsonc
+++ b/claude/roles/base.jsonc
@@ -185,6 +185,16 @@
         // it the very first thing any mcporter invocation prints is
         // "EPERM: operation not permitted, mkdir '~/.mcporter'".
         "~/.mcporter",
+        // Gusto's gusto-dev Claude Code plugin ships a PreToolUse hook that
+        // rewrites every `rm ...` Bash command to `trash ...` (macOS's
+        // built-in /usr/bin/trash, NSFileManager trashItem API) so deletes
+        // are recoverable. Without ~/.Trash allowlisted, the seatbelt
+        // profile denies `file-write-create` on ~/.Trash/<name> and macOS
+        // surfaces that as a cryptic NSCocoaErrorDomain 513 /
+        // "afpAccessDenied" error -- easy to mistake for a Finder/TCC
+        // permission problem rather than our own sandbox. Confirmed via
+        // `log show` kernel Sandbox denial lines (pickletown bean gt-1vxk).
+        "~/.Trash",
       ],
     },
   },


### PR DESCRIPTION
## Summary
- I use aa PreToolUse hook that rewrites every `rm ...` Bash command to `trash ...` (macOS's built-in `/usr/bin/trash`), so agent deletes are recoverable via the Trash.
- Without `~/.Trash` in the sandbox's `allowWrite` list, the seatbelt profile denies `file-write-create` on `~/.Trash/<name>`, and macOS surfaces that as a cryptic `NSCocoaErrorDomain 513` / `afpAccessDenied` error, easy to mistake for a Finder/TCC permission problem instead of our own sandbox.
- Confirmed the exact denial via `log show` kernel Sandbox lines: `Sandbox: trash(PID) deny(1) file-write-create /Users/.../.Trash/<name>`. Adding `~/.Trash` to `allowWrite` and regenerating settings fixes it with no `dangerouslyDisableSandbox` needed.

## Test plan
- [x] Reproduced the failure sandboxed on a `$TMPDIR` path before the fix
- [x] Confirmed success with `dangerouslyDisableSandbox: true` (isolated the sandbox as the cause)
- [x] Correlated with kernel `Sandbox: ... deny(1) file-write-create .../.Trash/...` log lines
- [x] Added `~/.Trash` to `claude/roles/base.jsonc` `allowWrite`, ran `./claudeconfig.sh`, confirmed `trash` now succeeds sandboxed with no local override