### PR TITLE
Move auto mode classifier rules into role sources

### DIFF
--- a/.beans/dotfiles-1bx8--create-work-machine-auto-mode-private-overlay.md
+++ b/.beans/dotfiles-1bx8--create-work-machine-auto-mode-private-overlay.md
@@ -1,0 +1,20 @@
+---
+# dotfiles-1bx8
+title: Create work-machine auto mode private overlay
+status: todo
+type: task
+created_at: 2026-09-09T01:24:44Z
+updated_at: 2026-09-09T01:24:44Z
+---
+
+On the work machine, the `work` role generates with base.jsonc's placeholder autoMode environment ("Organization: None configured" and friends). That is wrong there: a classifier told there is no organization reads an upload to an internal host as an upload to a stranger.
+
+claudeconfig.sh warns about this on every run, because work.jsonc sets `requiresPrivateOverlay: true`.
+
+## Steps
+- [ ] On the work machine, run `/auto-mode-setup`
+- [ ] Move the `autoMode` block it writes into `~/.config/dotpickles/roles/work.jsonc` (a full role file, same schema as claude/roles/*.jsonc)
+- [ ] Re-run `./claudeconfig.sh` and confirm the overlay line appears and the warning is gone
+- [ ] Sanity check `claude auto-mode config` shows the merged result
+
+Kept outside the dotfiles repo on purpose: this repo is public and the block names internal infrastructure. See doc/adr/0055-auto-mode-classifier-rules-in-role-sources.md.

--- a/.beans/dotfiles-4hu8--check-agent-ssh-key-asserts-coresshcommand-that-ho.md
+++ b/.beans/dotfiles-4hu8--check-agent-ssh-key-asserts-coresshcommand-that-ho.md
@@ -1,0 +1,29 @@
+---
+# dotfiles-4hu8
+title: check-agent-ssh-key asserts core.sshCommand that home role deliberately dropped
+status: todo
+type: bug
+created_at: 2026-09-09T01:30:42Z
+updated_at: 2026-09-09T01:30:42Z
+---
+
+`./claudeconfig.sh` applies all config successfully, then fails its final validation step:
+
+```
+✗ /Users/technicalpickles/.gitconfig.d/claude-agent-home missing core.sshCommand using /Users/technicalpickles/.ssh/agents/home/id_ed25519
+  got: ''
+1 failed, 7 passed
+✗ Agent SSH key validation failed (see above).
+```
+
+The check is stale, not the config. `home/.gitconfig.d/claude-agent-home` has no `core.sshCommand` **on purpose**, and says so in its own comment: "No core.sshCommand override: ssh/config.d/auth's Match block" handles key selection. claude/roles/home.jsonc explains the same thing at length: `GIT_SSH_COMMAND` is injected by the harness and resolves ahead of `core.sshCommand`, so a `core.sshCommand` override could never win. That design landed in d865817 ("fix(git): make home-role agent git actually use the SSH relay from #34").
+
+`bin/check-agent-ssh-key` never got the memo. It still asserts the value at line 295-304.
+
+Effect is cosmetic but noisy: every `./claudeconfig.sh` run ends in a red failure and a non-zero exit, after having applied everything correctly. That trains you to ignore the script's exit status, which is the actual cost.
+
+## Checklist
+- [ ] Decide whether the home role should still assert anything about key selection, and if so what (the ssh/config.d/auth Match block, maybe)
+- [ ] Update or drop the core.sshCommand assertion in bin/check-agent-ssh-key
+- [ ] Confirm the work role's expectations are unchanged (it may still legitimately set core.sshCommand)
+- [ ] Re-run ./claudeconfig.sh and confirm a clean exit

--- a/.beans/dotfiles-4hu8--check-agent-ssh-key-asserts-coresshcommand-that-ho.md
+++ b/.beans/dotfiles-4hu8--check-agent-ssh-key-asserts-coresshcommand-that-ho.md
@@ -1,10 +1,11 @@
 ---
 # dotfiles-4hu8
 title: check-agent-ssh-key asserts core.sshCommand that home role deliberately dropped
-status: todo
+status: completed
 type: bug
+priority: normal
 created_at: 2026-09-09T01:30:42Z
-updated_at: 2026-09-09T01:30:42Z
+updated_at: 2026-09-09T01:53:44Z
 ---
 
 `./claudeconfig.sh` applies all config successfully, then fails its final validation step:
@@ -23,7 +24,7 @@ The check is stale, not the config. `home/.gitconfig.d/claude-agent-home` has no
 Effect is cosmetic but noisy: every `./claudeconfig.sh` run ends in a red failure and a non-zero exit, after having applied everything correctly. That trains you to ignore the script's exit status, which is the actual cost.
 
 ## Checklist
-- [ ] Decide whether the home role should still assert anything about key selection, and if so what (the ssh/config.d/auth Match block, maybe)
-- [ ] Update or drop the core.sshCommand assertion in bin/check-agent-ssh-key
-- [ ] Confirm the work role's expectations are unchanged (it may still legitimately set core.sshCommand)
-- [ ] Re-run ./claudeconfig.sh and confirm a clean exit
+- [x] Decide whether the home role should still assert anything about key selection, and if so what (the ssh/config.d/auth Match block, maybe)
+- [x] Update or drop the core.sshCommand assertion in bin/check-agent-ssh-key
+- [x] Confirm the work role's expectations are unchanged (it may still legitimately set core.sshCommand)
+- [x] Re-run ./claudeconfig.sh and confirm a clean exit (All 8 checks passed)

--- a/.beans/dotfiles-936b--tighten-agent-ssh-key-check-to-require-exactly-one.md
+++ b/.beans/dotfiles-936b--tighten-agent-ssh-key-check-to-require-exactly-one.md
@@ -1,0 +1,27 @@
+---
+# dotfiles-936b
+title: Tighten agent ssh key check to require exactly one resolved identity
+status: todo
+type: task
+created_at: 2026-09-09T02:02:37Z
+updated_at: 2026-09-09T02:02:37Z
+---
+
+`bin/check-agent-ssh-key`'s `ssh -G` branch (home role, no core.sshCommand) currently substring-matches the agent key against the resolved identityfile list:
+
+```bash
+if [[ "${resolved_ids//\~\//$HOME/}" == *"$KEY_PATH"* && "$resolved_only" == "yes" ]]; then
+```
+
+That passes when the agent key is present *alongside* others. It should require exactly one.
+
+**Why it matters:** `IdentityFile` is additive, and `IdentitiesOnly=yes` does not drop config-supplied identities, only extra agent-offered ones. So a second identity in the resolved set means ssh still offers the human laptop key, and GitHub will happily accept it. Both keys live on the same account, so the "Hi <user>!" greeting is identical either way and check 7 cannot catch it. The script's own comment at check 7 makes exactly this argument about why `-F /dev/null` is needed there.
+
+Right now the home role does resolve to exactly one (verified 2026-09-08), so this is defense against a future `~/.ssh/config` change quietly widening it.
+
+The work role takes the `core.sshCommand` branch instead, so it is unaffected.
+
+## Checklist
+- [ ] Replace the substring match with a count check (exactly 1) plus an equality check against $KEY_PATH
+- [ ] Keep the existing `key_got` detail message, which already prints the full resolved list
+- [ ] Verify home still passes, and that adding a stray IdentityFile makes it fail

--- a/.beans/dotfiles-x8mh--move-automode-config-into-dotfiles-role-sources.md
+++ b/.beans/dotfiles-x8mh--move-automode-config-into-dotfiles-role-sources.md
@@ -1,10 +1,11 @@
 ---
 # dotfiles-x8mh
 title: Move autoMode config into dotfiles role sources
-status: in-progress
+status: completed
 type: task
+priority: normal
 created_at: 2026-09-09T00:58:54Z
-updated_at: 2026-09-09T00:58:54Z
+updated_at: 2026-09-09T01:30:49Z
 ---
 
 The `autoMode` block written by /auto-mode-setup lives in ~/.claude/settings.json, which claudeconfig.sh regenerates. Only enabledPlugins and extraKnownMarketplaces survive regeneration (claudeconfig.sh:170), so the whole auto mode classifier config gets silently wiped on the next run.
@@ -19,7 +20,7 @@ Move it into claude/roles/ so it is version-controlled and role-aware.
 - [x] Document the generated-key contract in claude/README.md
 - [x] ADR 0055
 - [x] Verify merge/override/regroup with a redirected-output probe
-- [ ] Run ./claudeconfig.sh for real (needs sandbox off; installs this branch's config globally)
+- [x] Run ./claudeconfig.sh for real (autoMode landed; `claude auto-mode config` confirms the merge)
 - [x] Work-machine overlay split out to dotfiles-1bx8
 
 ## Notes
@@ -30,3 +31,5 @@ before any claudeconfig.sh run. Recovered from the session transcript. Cause not
 Followup: the taskwarrior autoMode allow rule is scoped `in technicalpickles/dotfiles` but
 taskwarrior is the backlog system everywhere. Left as-is rather than silently widening a
 classifier allow rule.
+
+The regeneration exposed an unrelated stale assertion in bin/check-agent-ssh-key: dotfiles-4hu8.

--- a/.beans/dotfiles-x8mh--move-automode-config-into-dotfiles-role-sources.md
+++ b/.beans/dotfiles-x8mh--move-automode-config-into-dotfiles-role-sources.md
@@ -1,0 +1,32 @@
+---
+# dotfiles-x8mh
+title: Move autoMode config into dotfiles role sources
+status: in-progress
+type: task
+created_at: 2026-09-09T00:58:54Z
+updated_at: 2026-09-09T00:58:54Z
+---
+
+The `autoMode` block written by /auto-mode-setup lives in ~/.claude/settings.json, which claudeconfig.sh regenerates. Only enabledPlugins and extraKnownMarketplaces survive regeneration (claudeconfig.sh:170), so the whole auto mode classifier config gets silently wiped on the next run.
+
+Move it into claude/roles/ so it is version-controlled and role-aware.
+
+## Checklist
+- [x] Teach claudeconfig.sh to merge autoMode.{allow,soft_deny,hard_deny,environment} across base/role/stacks
+- [x] Split current rules between base.jsonc, home.jsonc, beans.jsonc, taskwarrior.jsonc
+- [x] Support a private overlay at ~/.config/dotpickles/roles/<role>.jsonc, merged last
+- [x] Loud guard via requiresPrivateOverlay when the overlay is missing
+- [x] Document the generated-key contract in claude/README.md
+- [x] ADR 0055
+- [x] Verify merge/override/regroup with a redirected-output probe
+- [ ] Run ./claudeconfig.sh for real (needs sandbox off; installs this branch's config globally)
+- [x] Work-machine overlay split out to dotfiles-1bx8
+
+## Notes
+
+The live autoMode block disappeared from ~/.claude/settings.json mid-session on 2026-09-08,
+before any claudeconfig.sh run. Recovered from the session transcript. Cause not established.
+
+Followup: the taskwarrior autoMode allow rule is scoped `in technicalpickles/dotfiles` but
+taskwarrior is the backlog system everywhere. Left as-is rather than silently widening a
+classifier allow rule.

--- a/.config/prettier/ignore
+++ b/.config/prettier/ignore
@@ -33,3 +33,11 @@
 # in place (4-space indent) whenever its settings change, since
 # ~/.config/karabiner is symlinked straight to this repo path
 **/karabiner/karabiner.json
+
+# same idea, one step removed: this is a copy of what ccstatusline itself
+# writes to ~/.config/ccstatusline (not symlinked, copied in by hand after
+# changing the status line). prettier wants single-element arrays collapsed
+# onto one line, the tool writes them expanded, so the file goes
+# out-of-format again every time it is refreshed. It had CI red on main for
+# days before anyone tied the failure to it.
+**/config/ccstatusline/settings.json

--- a/bin/check-agent-ssh-key
+++ b/bin/check-agent-ssh-key
@@ -275,9 +275,29 @@ fi
 # --- 6. ~/.claude/settings.json + gitconfig include ---
 # Verify GIT_CONFIG_GLOBAL is wired to a gitconfig include file, the file
 # exists, and it overrides the settings that matter: user.email (or git
-# won't attribute to the agent), core.sshCommand (or ssh will use
-# 1Password's IdentityAgent), and gpg.ssh.program=ssh-keygen (or signing
-# falls through to 1Password's op-ssh-sign and fails).
+# won't attribute to the agent), gpg.ssh.program=ssh-keygen (or signing
+# falls through to 1Password's op-ssh-sign and fails), and that ssh ends up
+# using this role's agent key rather than the human laptop key.
+#
+# That last one has two valid shapes, and which one a role uses is a design
+# decision rather than an accident:
+#
+#   core.sshCommand set     git names the key itself (work role, which needs
+#                           -F /dev/null to shut out the `Host *` block's
+#                           IdentityFile).
+#   core.sshCommand absent  ~/.ssh/config does it, through Match blocks keyed
+#                           on $CLAUDECODE and $DOTPICKLES_ROLE
+#                           (ssh/config.d/auth, ssh/config.d/agent-relay).
+#                           The home role works this way on purpose: the
+#                           harness injects GIT_SSH_COMMAND into every Bash
+#                           tool call, git resolves that ahead of
+#                           core.sshCommand, so a core.sshCommand override
+#                           there could never win. See claude/roles/home.jsonc.
+#
+# So assert the invariant both shapes share -- ssh resolves to this role's
+# key and nothing else -- instead of one mechanism's spelling. Asserting
+# core.sshCommand unconditionally is what made this check fail on the home
+# role after it deliberately dropped that override (bean dotfiles-4hu8).
 if [[ -f "$SETTINGS" ]]; then
   git_config_global=$(jq -r '.env.GIT_CONFIG_GLOBAL // empty' "$SETTINGS")
   # Expand leading ~/ for the check (claudeconfig.sh writes absolute paths,
@@ -297,17 +317,58 @@ if [[ -f "$SETTINGS" ]]; then
     # Normalize ~/ in the sshCommand value so the check accepts either form.
     cfg_ssh_expanded="${cfg_ssh//\~\//$HOME/}"
 
+    key_selection_ok=false
+    key_selection_how=""
+    key_selection_detail=""
+
+    if [[ -n "$cfg_ssh" ]]; then
+      if [[ "$cfg_ssh_expanded" == *"$KEY_PATH"* ]]; then
+        key_selection_ok=true
+        key_selection_how="core.sshCommand"
+      else
+        key_selection_detail="core.sshCommand is set but does not use $KEY_PATH (got: '$cfg_ssh')"
+      fi
+    else
+      # Ask ssh what it would actually do. The Match blocks test $CLAUDECODE
+      # and $DOTPICKLES_ROLE in a subshell at connect time, so set both --
+      # otherwise this resolves the interactive shape (every stock key in
+      # ~/.ssh, IdentitiesOnly no) and reports a false failure. -G resolves
+      # config and exits; it never dials the host, so the relay's
+      # ProxyCommand does not run.
+      ssh_resolved=$(CLAUDECODE=1 DOTPICKLES_ROLE="$ROLE" ssh -G git@github.com 2> /dev/null || true)
+      resolved_ids=$(awk '$1 == "identityfile" { print $2 }' <<< "$ssh_resolved")
+      resolved_only=$(awk '$1 == "identitiesonly" { print $2 }' <<< "$ssh_resolved")
+      resolved_count=$(grep -c . <<< "$resolved_ids")
+      resolved_expanded="${resolved_ids//\~\//$HOME/}"
+
+      if [[ -z "$ssh_resolved" ]]; then
+        key_selection_detail="no core.sshCommand, and 'ssh -G git@github.com' failed, so key selection can't be verified"
+      elif [[ "$resolved_count" != 1 ]]; then
+        # More than one candidate means the human laptop key is still in play:
+        # IdentityFile is additive and IdentitiesOnly does not drop
+        # config-supplied identities, so ssh can authenticate as the human.
+        key_selection_detail="ssh resolves $resolved_count identities for git@github.com, want exactly 1 ($KEY_PATH): $(tr '\n' ' ' <<< "$resolved_ids")"
+      elif [[ "$resolved_expanded" != "$KEY_PATH" ]]; then
+        key_selection_detail="ssh resolves $resolved_expanded, want $KEY_PATH"
+      elif [[ "$resolved_only" != "yes" ]]; then
+        key_selection_detail="ssh resolves IdentitiesOnly=$resolved_only, want yes (the agent can otherwise offer other keys)"
+      else
+        key_selection_ok=true
+        key_selection_how="~/.ssh/config"
+      fi
+    fi
+
     if [[ "$cfg_email" != "$EMAIL" ]]; then
       check_fail "$expanded_path missing user.email=$EMAIL" \
         "got: '$cfg_email'"
-    elif [[ "$cfg_ssh_expanded" != *"$KEY_PATH"* ]]; then
-      check_fail "$expanded_path missing core.sshCommand using $KEY_PATH" \
-        "got: '$cfg_ssh'"
     elif [[ "$cfg_gpg" != "ssh-keygen" ]]; then
       check_fail "$expanded_path missing gpg.ssh.program=ssh-keygen" \
         "got: '$cfg_gpg' (1Password's op-ssh-sign will block agent signing)"
+    elif ! $key_selection_ok; then
+      check_fail "$IDENTITY agent key is not what ssh would use for github.com" \
+        "$key_selection_detail"
     else
-      check_pass "Agent gitconfig include wired up ($expanded_path)"
+      check_pass "Agent gitconfig include wired up ($expanded_path; key via $key_selection_how)"
     fi
   fi
 else

--- a/claude/README.md
+++ b/claude/README.md
@@ -102,12 +102,13 @@ All keys are optional. A stack can have only `permissions`, only `sandbox`, or b
 
 When you run `./claudeconfig.sh`:
 
-1. **Base role** (`roles/base.jsonc`): settings, permissions, and sandbox extracted
-2. **Active role** (`roles/$ROLE.jsonc`): settings deep-merged on top of base. Permissions and sandbox arrays concatenated (not deep-merged, which would replace arrays)
-3. **Stacks** (`stacks/*.jsonc`, sorted alphabetically): permissions and sandbox arrays concatenated
-4. **Deduplication**: all arrays sorted and deduplicated
-5. **Local keys**: `enabledPlugins`, `extraKnownMarketplaces` preserved from existing `~/.claude/settings.json`
-6. **Validation and write**
+1. **Base role** (`roles/base.jsonc`): settings, permissions, sandbox, and `autoMode` extracted
+2. **Active role** (`roles/$ROLE.jsonc`): settings deep-merged on top of base. Permissions, sandbox and `autoMode` arrays concatenated (not deep-merged, which would replace arrays)
+3. **Stacks** (`stacks/*.jsonc`, sorted alphabetically): permissions, sandbox and `autoMode` arrays concatenated
+4. **Private overlay** (`~/.config/dotpickles/roles/$ROLE.jsonc`, optional): a full role file kept outside this repo, merged last so it wins over everything above. See [Auto Mode Rules](#auto-mode-rules)
+5. **Deduplication**: permissions and sandbox arrays sorted and deduplicated. `autoMode` arrays are deduplicated but **never sorted** -- order carries meaning there
+6. **Local keys**: `enabledPlugins`, `extraKnownMarketplaces` preserved from existing `~/.claude/settings.json`
+7. **Validation and write**
 
 ## Common Tasks
 
@@ -213,6 +214,31 @@ When you notice you're repeatedly approving the same permission across projects:
 3. **Regenerate**: `./claudeconfig.sh`
 4. **Clean up**: `claude-permissions cleanup --force`
 5. **Commit** to dotfiles
+
+## Auto Mode Rules
+
+The `autoMode` block feeds the LLM classifier that adjudicates tool calls while `defaultMode` is `auto`. It is generated like everything else, from `roles/` + `stacks/` + the private overlay. See [ADR 0055](../doc/adr/0055-auto-mode-classifier-rules-in-role-sources.md) for the full reasoning.
+
+**It has to be generated into user settings.** Claude Code honours `autoMode` from user, `--settings` and managed settings only. Rules in a repo's `.claude/settings.json` are read, recognized, and deliberately ignored, because a cloned repo must not be able to talk the classifier into trusting it.
+
+**`/auto-mode-setup` writes the wrong file.** It writes `~/.claude/settings.json`, which the next `./claudeconfig.sh` overwrites. So does `claude auto-mode reset`. Port anything you want to keep back into `roles/` or `stacks/`. Same contract as every other generated key, but this one has a CLI that invites you to edit it directly.
+
+**Order matters, so these arrays are never sorted:**
+
+- `$defaults` is a splice point. The shipped rules get inserted where that entry sits, so it stays first.
+- An `allow`/`soft_deny`/`hard_deny` array without `$defaults` **replaces** the shipped rules instead of extending them. The generator prepends it if it is missing.
+- `environment` is header-grouped: `### Org-wide` and `### User-specific`, each holding `**Label**: value` bullets from a fixed label list. The generator regroups by section after concatenating, and a later source's bullet **replaces** an earlier one with the same `**Label**`, in the earlier one's position.
+
+**Where things go:**
+
+| Content                                           | File                                     |
+| ------------------------------------------------- | ---------------------------------------- |
+| Role-invariant facts, `$defaults`, shipped labels | `roles/base.jsonc`                       |
+| A tool's own carve-out                            | that tool's `stacks/*.jsonc`             |
+| Home-only additions                               | `roles/home.jsonc`                       |
+| Anything that can't be public                     | `~/.config/dotpickles/roles/$ROLE.jsonc` |
+
+A role that needs the private overlay sets `"requiresPrivateOverlay": true` (stripped before writing settings). Without the overlay, `claudeconfig.sh` warns loudly rather than silently generating `base.jsonc`'s placeholder answers.
 
 ## Local Keys
 

--- a/claude/roles/base.jsonc
+++ b/claude/roles/base.jsonc
@@ -58,6 +58,64 @@
     "NODE_USE_ENV_PROXY": "1",
   },
 
+  // Auto mode classifier rules (see ADR 0055).
+  //
+  // These are plain-English strings spliced into the system prompt of the LLM
+  // that adjudicates tool calls while defaultMode is "auto". Claude Code only
+  // honours autoMode from user, --settings, or managed settings -- it reads
+  // projectSettings and localSettings, finds rules there, and deliberately
+  // ignores them ("projectSettings and localSettings are repo-controllable"),
+  // so a checked-in .claude/settings.json can never contribute. That is why
+  // this lives in the generated ~/.claude/settings.json and therefore has to
+  // live here in source.
+  //
+  // Ordering rules that claudeconfig.sh enforces, worth knowing before you
+  // edit: "$defaults" is a splice point for the shipped rules, so it stays
+  // first; environment is grouped under "### Org-wide" / "### User-specific"
+  // headers holding "**Label**: value" bullets from a fixed label list; and a
+  // role or stack bullet with the same **Label** replaces the one here rather
+  // than sitting alongside it.
+  //
+  // Base holds the role-invariant picture: this repo, this laptop, and the
+  // shipped "None configured" text for the org-shaped slots (correct as-is
+  // under the home role). work.jsonc overrides the slots Gusto changes.
+  // Roles and stacks omit "$defaults" -- the generator guarantees it.
+  "autoMode": {
+    "allow": ["$defaults", "Bash(herdr:*) in technicalpickles/dotfiles"],
+    "soft_deny": [
+      "$defaults",
+      "Bash(rm -rf:*) in technicalpickles/dotfiles — repo docs show a prior EPERM/sandbox workaround pattern around forced writes; keep destructive rm under review",
+      "Push to origin over SSH (git@github.com:) — repo docs say agent sessions rewrite this to HTTPS; a literal SSH push attempt is unexpected and worth a second look",
+    ],
+    "environment": [
+      "### Org-wide",
+      "**Organization**: None configured",
+      "**Cloud provider(s)**: None configured",
+      "**Repository visibility**: PUBLIC — technicalpickles/dotfiles (github.com). Any push to this repo's origin is publishing.",
+      "**Internal sharing / snippet hosting**: None configured — treat public paste/gist services as outside the trust boundary",
+      "**Secrets management**: 1Password (`op`) — referenced in repo docs (ADR 0033, ADR 0032 fnox) and used in shell history (`op` 26×, `bw` 37×)",
+      "**Default / protected branches**: `main` (protected, per gh); no rulesets configured",
+      "**CI/CD deploy targets**: None configured",
+      "**Network posture**: None configured",
+      "**Host containment**: None configured — assume Claude Code runs on an ordinary developer machine with open internet; note repo docs describe a Seatbelt/sandbox layer (outbound port 22 to github.com blocked, some paths under `~/.claude/` denied for writes) but this is local sandboxing, not a declared network/identity containment boundary — the classifier cannot verify sandbox state from commands alone",
+      "**Source control**: The trusted repo (technicalpickles/dotfiles) and its origin remote (github.com:technicalpickles/dotfiles.git) only",
+      "**Trusted internal domains**: None configured",
+      "**Trusted cloud buckets**: None configured",
+      "**Key internal services**: None configured",
+      "**Internal package registry**: None configured",
+      "**Sensitive data locations & audiences**: `home/.bash_profile.d/private`, `config/fish/conf.d/fish_frozen_key_bindings.fish`, `config/fish/functions/_tide_item_private_mode.fish` (gitignored — treat as personal secrets/private material, never commit); `.beans/dotfiles-fyjp--fix-1password-allowlist-socket-gate-in-sshconfigsh.md`, `.beans/dotfiles-wswz--1password-ssh-agent-allowlist-not-installed-agent.md`, `doc/adr/0032-use-fnox-for-secrets.md`, `doc/adr/0033-1password-ssh-agent-allowlist.md` (secrets-management design docs — handle normally as tracked repo docs, but avoid pasting live secret values into them)",
+      "**Data retention / declassification**: None configured",
+      "**Sensitive remote targets**: any namespace, host, or container whose name carries `prod` or `production` as a whole word or name segment",
+      "**Protected deployment namespaces / environments**: None configured — fall back to the Sensitive remote targets heuristic",
+      "**Protected IaC scopes**: IAM, RBAC, networking, quota, and node-pool resources; anything whose name or tag carries `prod` or `production` as a whole word or name segment",
+      "### User-specific",
+      "**Primary use of Claude Code**: personal dotfiles / developer tooling maintenance (shell configs, git settings, macOS preferences, Claude Code's own configuration)",
+      "**Trusted repo**: technicalpickles/dotfiles (public) — its own work is fine to push there; content ported from other repos/sessions is not",
+      "**Org-specific CLIs**: `beans` (agentic issue tracker, this repo), `herdr` (plugin manager, this repo — `config/herdr/plugins.toml`), `claudeconfig.sh`, `sshconfig.sh`, `gitconfig.sh`, `bin/adr` — all repo-local scripts/CLIs, routine under this repo",
+      "routine under technicalpickles/dotfiles: edits to `claude/`, `.claude/rules/`, `home/`, `config/`, `ssh/config.d/` followed by the documented regeneration scripts (`claudeconfig.sh`, `sshconfig.sh`, `gitconfig.sh`)",
+    ],
+  },
+
   // Permissions: base safety rules
   "permissions": {
     "defaultMode": "auto",

--- a/claude/roles/home.jsonc
+++ b/claude/roles/home.jsonc
@@ -30,6 +30,20 @@
     },
   },
 
+  // Auto mode: base.jsonc already describes the home posture (no org, no
+  // cloud, public dotfiles repo, "None configured" across the org-shaped
+  // slots), so this only adds what is specific to this machine. A bullet
+  // here replaces the base bullet carrying the same **Label**. See ADR 0055.
+  "autoMode": {
+    "environment": [
+      "### Org-wide",
+      "**Trusted internal domains**: `brineworks.tail2023b7.ts.net` (Tailscale tailnet, this machine's own node) — allowlisted in the sandbox above; nothing else is internal",
+      "### User-specific",
+      "**Trusted repo**: technicalpickles/dotfiles (public) and the rest of `~/github.com/technicalpickles/` — each repo's own work is fine to push to its own origin; content ported from another repo or session is not",
+      "routine under technicalpickles/: work on the pickled-coi VM (an OrbStack VM, mirrors most of `~/github.com/technicalpickles/` under its own `~/projects/`) is ordinary development, not a remote-host escalation — see ~/github.com/CLAUDE.md",
+    ],
+  },
+
   // Nudge (non-blocking) when a Write/Edit lands a bare numeric task/plan-step
   // ID in a durable, resumed-later artifact (.parkinglot handoffs, .beans,
   // auto-memory files). See claude/rules/taskwarrior.md and bean

--- a/claude/roles/work.jsonc
+++ b/claude/roles/work.jsonc
@@ -52,6 +52,29 @@
     },
   },
 
+  // Auto mode classifier rules: intentionally absent from this file.
+  //
+  // base.jsonc's org-shaped slots carry the shipped "None configured" text.
+  // That is correct at home and flatly wrong here -- a classifier told there
+  // is no organization judges an upload to a Gusto host as an upload to a
+  // stranger -- so the work role does need its own environment bullets.
+  //
+  // They just cannot live here: this repo is public, and a filled-in work
+  // environment block spells out org name, internal services, deploy targets
+  // and protected namespaces in one place. Some of that already leaks through
+  // the sandbox allowlist above; the classifier block would be a much fuller
+  // picture.
+  //
+  // They live in ~/.config/dotpickles/roles/work.jsonc instead, which
+  // claudeconfig.sh merges last. Generate it by running /auto-mode-setup on
+  // the work machine and moving the autoMode block it writes into that file.
+  // See ADR 0055.
+  //
+  // The flag below is not a Claude Code setting -- claudeconfig.sh strips it
+  // and uses it to warn when the overlay is missing, so this role never
+  // quietly generates with base.jsonc's placeholder answers.
+  "requiresPrivateOverlay": true,
+
   // Pickleton session tracking hooks (global so they fire in all directories,
   // not just when Claude starts in ~/pickleton itself)
   "hooks": {

--- a/claude/stacks/beans.jsonc
+++ b/claude/stacks/beans.jsonc
@@ -11,4 +11,12 @@
     ],
     "ask": ["Bash(beans archive:*)", "Bash(beans delete:*)"],
   },
+
+  // Auto mode: beans is a non-standard CLI, so the classifier has no prior on
+  // it and would otherwise soft-block routine bean writes. Scoped to the repo
+  // that actually uses it. No "$defaults" here -- claudeconfig.sh keeps the
+  // one from base.jsonc at the front. See ADR 0055.
+  "autoMode": {
+    "allow": ["Bash(beans:*) in technicalpickles/dotfiles"],
+  },
 }

--- a/claude/stacks/taskwarrior.jsonc
+++ b/claude/stacks/taskwarrior.jsonc
@@ -2,6 +2,16 @@
   "permissions": {
     "allow": ["Bash(task:*)"],
   },
+
+  // Auto mode carve-out for the same CLI. Note the asymmetry with the
+  // permissions entry above: that one is unscoped, this one names the repo,
+  // because that is the scope the /auto-mode-setup recon actually supported.
+  // Taskwarrior is the backlog system everywhere (claude/rules/taskwarrior.md),
+  // so this probably wants widening -- but widening a classifier allow rule is
+  // a deliberate call, not a tidy-up. See ADR 0055.
+  "autoMode": {
+    "allow": ["Bash(task:*) in technicalpickles/dotfiles"],
+  },
   "sandbox": {
     "filesystem": {
       "allowWrite": ["~/.task"],

--- a/claudeconfig.sh
+++ b/claudeconfig.sh
@@ -159,6 +159,21 @@ setup_sandbox_dirs() {
 
 setup_sandbox_dirs
 
+# Append one source's autoMode arrays onto the accumulators generate_settings
+# declares. Roles and stacks both feed through here, so a stack can carry the
+# classifier rule for its own tool right next to the permissions entry for it
+# (beans.jsonc owning both `Bash(beans:*)` lines, say).
+merge_auto_mode() {
+  local src="$1"
+  local key
+  for key in allow soft_deny hard_deny environment; do
+    local var="auto_${key}"
+    local incoming
+    incoming=$(echo "$src" | jq ".autoMode.${key} // []")
+    printf -v "$var" '%s' "$(echo "${!var}" | jq --argjson r "$incoming" '. + $r')"
+  done
+}
+
 # Generate settings.json from roles/ + stacks/
 generate_settings() {
   echo "Generating settings.json..."
@@ -189,9 +204,11 @@ generate_settings() {
   local base_json
   base_json=$(read_json "$base_role")
 
-  # Extract settings (everything except permissions and sandbox)
+  # Extract settings (everything except permissions, sandbox and autoMode --
+  # all three are array-carrying and get concatenated across sources below,
+  # not deep-merged, since jq's `*` replaces arrays wholesale)
   local merged_settings
-  merged_settings=$(echo "$base_json" | jq 'del(.permissions, .sandbox)')
+  merged_settings=$(echo "$base_json" | jq 'del(.permissions, .sandbox, .autoMode, .requiresPrivateOverlay)')
 
   # Extract permissions arrays from base
   local merged_allow merged_ask merged_deny
@@ -209,6 +226,16 @@ generate_settings() {
   sandbox_hosts=$(echo "$base_json" | jq '.sandbox.network.allowedDomains // []')
   sandbox_write_paths=$(echo "$base_json" | jq '.sandbox.filesystem.allowWrite // []')
 
+  # Extract auto mode classifier rules from base. These are plain-English
+  # strings that Claude Code splices into the classifier's system prompt, so
+  # they behave differently from every other array here -- see the ordering
+  # note further down before touching this.
+  local auto_allow auto_soft_deny auto_hard_deny auto_environment
+  auto_allow=$(echo "$base_json" | jq '.autoMode.allow // []')
+  auto_soft_deny=$(echo "$base_json" | jq '.autoMode.soft_deny // []')
+  auto_hard_deny=$(echo "$base_json" | jq '.autoMode.hard_deny // []')
+  auto_environment=$(echo "$base_json" | jq '.autoMode.environment // []')
+
   echo "  + Loaded base role"
 
   # --- Load active role (if not base) ---
@@ -221,13 +248,15 @@ generate_settings() {
     echo "     No role-specific env (e.g. GIT_CONFIG_GLOBAL) or sandbox rules will apply." >&2
     echo "     Check DOTPICKLES_ROLE and claude/roles/ for a name mismatch." >&2
   fi
+  # Declared out here (not inside the if) so the private-overlay guard further
+  # down can still read requiresPrivateOverlay off it.
+  local role_json="{}"
   if [ -f "$role_file" ] && [ "$ROLE" != "base" ]; then
-    local role_json
     role_json=$(read_json "$role_file")
 
     # Deep merge settings keys (role overrides base)
     local role_settings
-    role_settings=$(echo "$role_json" | jq 'del(.permissions, .sandbox)')
+    role_settings=$(echo "$role_json" | jq 'del(.permissions, .sandbox, .autoMode, .requiresPrivateOverlay)')
     merged_settings=$(echo "$merged_settings" | jq --argjson role "$role_settings" '. * $role')
 
     # Concat permissions arrays (not deep merge, which would replace)
@@ -248,6 +277,9 @@ generate_settings() {
     # Concat sandbox arrays
     sandbox_hosts=$(echo "$sandbox_hosts" | jq --argjson r "$(echo "$role_json" | jq '.sandbox.network.allowedDomains // []')" '. + $r')
     sandbox_write_paths=$(echo "$sandbox_write_paths" | jq --argjson r "$(echo "$role_json" | jq '.sandbox.filesystem.allowWrite // []')" '. + $r')
+
+    # Concat auto mode rules (role appends to base, never replaces it)
+    merge_auto_mode "$role_json"
 
     echo "  + Loaded $ROLE role"
   fi
@@ -279,8 +311,66 @@ generate_settings() {
     sandbox_hosts=$(echo "$sandbox_hosts" | jq --argjson s "$(echo "$stack_json" | jq '.sandbox.network.allowedDomains // []')" '. + $s')
     sandbox_write_paths=$(echo "$sandbox_write_paths" | jq --argjson s "$(echo "$stack_json" | jq '.sandbox.filesystem.allowWrite // []')" '. + $s')
 
+    # Concat auto mode rules
+    merge_auto_mode "$stack_json"
+
     echo "  + Merged $stack_name stack"
   done
+
+  # --- Load the private overlay, if there is one ---
+  #
+  # An optional role file kept OUTSIDE this repo, for config that is real but
+  # cannot be public. The case that forced it: autoMode.environment tells the
+  # classifier who you work for, which hosts are internal, and which namespaces
+  # are protected. base.jsonc carries the shipped "None configured" text for
+  # those slots, which is true under the home role and dangerously wrong under
+  # work -- a classifier told there is no organization reads an upload to a
+  # company host as an upload to a stranger. Filling those slots in means
+  # naming internal infrastructure, and this repo is public.
+  #
+  # Deliberately not a gitignored file in claude/roles/: this survives a fresh
+  # clone of dotfiles, and there is no `git add -f` that can leak it.
+  #
+  # It is a full role file, not an autoMode-only one -- same schema, same merge
+  # rules -- and it is applied LAST so it wins over base, role and stacks alike.
+  local private_overlay="${XDG_CONFIG_HOME:-$HOME/.config}/dotpickles/roles/$ROLE.jsonc"
+  if [ -f "$private_overlay" ]; then
+    local overlay_json
+    overlay_json=$(read_json "$private_overlay")
+
+    local overlay_settings
+    overlay_settings=$(echo "$overlay_json" | jq 'del(.permissions, .sandbox, .autoMode, .requiresPrivateOverlay)')
+    merged_settings=$(echo "$merged_settings" | jq --argjson o "$overlay_settings" '. * $o')
+
+    merged_allow=$(echo "$merged_allow" | jq --argjson o "$(echo "$overlay_json" | jq '.permissions.allow // []')" '. + $o')
+    merged_ask=$(echo "$merged_ask" | jq --argjson o "$(echo "$overlay_json" | jq '.permissions.ask // []')" '. + $o')
+    merged_deny=$(echo "$merged_deny" | jq --argjson o "$(echo "$overlay_json" | jq '.permissions.deny // []')" '. + $o')
+
+    local overlay_permissions_scalars
+    overlay_permissions_scalars=$(echo "$overlay_json" | jq '.permissions // {} | del(.allow, .ask, .deny)')
+    permissions_scalars=$(echo "$permissions_scalars" | jq --argjson o "$overlay_permissions_scalars" '. * $o')
+
+    local overlay_sandbox_scalars
+    overlay_sandbox_scalars=$(echo "$overlay_json" | jq '.sandbox // {} | del(.network.allowedDomains, .filesystem.allowWrite, .filesystem, .network) + (if .network then {network: (.network | del(.allowedDomains))} else {} end) | del(.network | nulls) | del(.filesystem | nulls)')
+    sandbox_scalars=$(echo "$sandbox_scalars" | jq --argjson o "$overlay_sandbox_scalars" '. * $o')
+
+    sandbox_hosts=$(echo "$sandbox_hosts" | jq --argjson o "$(echo "$overlay_json" | jq '.sandbox.network.allowedDomains // []')" '. + $o')
+    sandbox_write_paths=$(echo "$sandbox_write_paths" | jq --argjson o "$(echo "$overlay_json" | jq '.sandbox.filesystem.allowWrite // []')" '. + $o')
+
+    merge_auto_mode "$overlay_json"
+
+    echo "  + Loaded private overlay ($private_overlay)"
+  elif [ "$(echo "$role_json" | jq -r '.requiresPrivateOverlay // false')" = "true" ]; then
+    # Loud guard, same reasoning as the missing-role-file warning above: the
+    # failure is silent and points the wrong way. Without the overlay the
+    # classifier keeps base.jsonc's "None configured" answers and treats an
+    # internal host like any host on the internet.
+    echo "  ⚠️  WARNING: role '$ROLE' declares requiresPrivateOverlay, but" >&2
+    echo "     $private_overlay does not exist." >&2
+    echo "     Settings will generate with base.jsonc's placeholder autoMode" >&2
+    echo "     environment ('Organization: None configured' and friends), which" >&2
+    echo "     is wrong for this role. See doc/adr/0055-auto-mode-classifier-rules-in-role-sources.md" >&2
+  fi
 
   # Deduplicate and sort all arrays
   merged_allow=$(echo "$merged_allow" | jq 'unique | sort')
@@ -288,6 +378,88 @@ generate_settings() {
   merged_deny=$(echo "$merged_deny" | jq 'unique | sort')
   sandbox_hosts=$(echo "$sandbox_hosts" | jq 'unique | sort')
   sandbox_write_paths=$(echo "$sandbox_write_paths" | jq 'unique | sort')
+
+  # Auto mode arrays are ORDER-SENSITIVE. Do NOT `sort` them the way the
+  # permissions and sandbox arrays above are sorted.
+  #
+  # Two reasons:
+  #
+  # 1. "$defaults" is a splice point, not a flag. Claude Code's settings
+  #    schema describes it as "include the literal string \"$defaults\" to
+  #    inherit the built-in rules at that position" -- the shipped rules get
+  #    spliced in where the entry sits, so moving it moves them.
+  # 2. autoMode.environment is a structured document, not a set. Its
+  #    "### Org-wide" / "### User-specific" entries are section headers that
+  #    group the lines following them. Sorting scatters lines out from under
+  #    their headers and the classifier reads the wreckage as one flat list.
+  #
+  # So: concatenate base -> role -> stacks in source order and dedupe keeping
+  # the FIRST occurrence. jq's `unique` keeps one of each but sorts as a side
+  # effect, which is the one thing we can't do, hence the reduce.
+  local dedupe_keep_first='reduce .[] as $x ([]; if index([$x]) then . else . + [$x] end)'
+  auto_allow=$(echo "$auto_allow" | jq "$dedupe_keep_first")
+  auto_soft_deny=$(echo "$auto_soft_deny" | jq "$dedupe_keep_first")
+  auto_hard_deny=$(echo "$auto_hard_deny" | jq "$dedupe_keep_first")
+
+  # autoMode.environment needs more than concatenation: it is header-grouped,
+  # not a flat list. Claude Code's setup writes exactly two sections,
+  # "### Org-wide" and "### User-specific", each holding "**Label**: value"
+  # bullets drawn from a fixed label list. Plain concatenation would land
+  # home.jsonc's Org-wide bullets after base.jsonc's User-specific ones and
+  # the classifier would read them under the wrong heading.
+  #
+  # So regroup by section. Within a section, a later source's bullet REPLACES
+  # an earlier source's bullet carrying the same **Label**, in the position
+  # the earlier one established -- role beats base, the same way role beats
+  # base for every scalar in this script, which is what lets base.jsonc hold
+  # the role-invariant facts and home/work override just the ones that differ.
+  # Unlabelled lines (the "routine under <user>/..." qualifiers) have no key
+  # to collide on, so they dedupe on exact text and keep first-seen order.
+  local regroup_environment='
+    def lbl: if type == "string" then (capture("^\\*\\*(?<l>[^*]+)\\*\\*\\s*:") | .l)? // null else null end;
+    reduce .[] as $x (
+      {cur: null, order: [], sec: {}};
+      if ($x | startswith("### ")) then
+        .cur = $x
+        | (if (.order | index([$x])) then . else .order += [$x] end)
+        | .sec[$x] = (.sec[$x] // [])
+      else
+        (.cur // "### Org-wide") as $c
+        | (if (.order | index([$c])) then . else .order += [$c] end)
+        | .sec[$c] = (.sec[$c] // [])
+        | ($x | lbl) as $k
+        | if $k == null then
+            (if (.sec[$c] | index([$x])) then . else .sec[$c] += [$x] end)
+          else
+            (.sec[$c] | map(lbl) | index([$k])) as $i
+            | if $i == null then .sec[$c] += [$x] else .sec[$c][$i] = $x end
+          end
+      end
+    )
+    | [ .order[] as $h | ([$h] + .sec[$h])[] ]'
+  auto_environment=$(echo "$auto_environment" | jq "$regroup_environment")
+
+  # A non-empty allow/soft_deny/hard_deny array WITHOUT "$defaults" silently
+  # replaces the shipped classifier rules instead of extending them -- i.e. a
+  # stack that adds one narrow allow rule would drop every built-in rule with
+  # it. Claude Code rejects that on its own write path; nothing stops us from
+  # generating it, so guard here. environment never carries "$defaults".
+  local guard_defaults='if length > 0 and (index(["$defaults"]) | not) then ["$defaults"] + . else . end'
+  auto_allow=$(echo "$auto_allow" | jq "$guard_defaults")
+  auto_soft_deny=$(echo "$auto_soft_deny" | jq "$guard_defaults")
+  auto_hard_deny=$(echo "$auto_hard_deny" | jq "$guard_defaults")
+
+  # Assemble the block, dropping empty sections and the whole key when no
+  # source contributed anything (an empty array is a validation error, and an
+  # absent autoMode key is what "just use the shipped defaults" looks like).
+  local auto_mode
+  auto_mode=$(jq -n \
+    --argjson allow "$auto_allow" \
+    --argjson soft_deny "$auto_soft_deny" \
+    --argjson hard_deny "$auto_hard_deny" \
+    --argjson environment "$auto_environment" \
+    '{allow: $allow, soft_deny: $soft_deny, hard_deny: $hard_deny, environment: $environment}
+     | with_entries(select(.value | length > 0))')
 
   # macOS: /tmp, /var and /etc are symlinks into /private, and the Seatbelt
   # sandbox matches the *resolved* path. An allowWrite entry spelled "/tmp"
@@ -347,13 +519,15 @@ generate_settings() {
     --argjson sandbox_scalars "$sandbox_scalars" \
     --argjson hosts "$sandbox_hosts" \
     --argjson write_paths "$sandbox_write_paths" \
+    --argjson auto_mode "$auto_mode" \
     '. + {
       permissions: ($perm_scalars + {allow: $allow, ask: $ask, deny: $deny}),
       sandbox: ($sandbox_scalars + {
         network: ($sandbox_scalars.network // {} | . + {allowedDomains: $hosts}),
         filesystem: {allowWrite: $write_paths}
       })
-    }')
+    }
+    + (if ($auto_mode | length) > 0 then {autoMode: $auto_mode} else {} end)')
 
   # Merge in local-only settings
   final_settings=$(echo "$final_settings" | jq --argjson local "$local_settings" '. * $local')

--- a/doc/adr/0055-auto-mode-classifier-rules-in-role-sources.md
+++ b/doc/adr/0055-auto-mode-classifier-rules-in-role-sources.md
@@ -1,0 +1,60 @@
+# 55. Auto mode classifier rules in role sources
+
+Date: 2026-09-08
+
+## Status
+
+2026-09-08 accepted
+
+## Context and Problem Statement
+
+Claude Code's auto mode adjudicates each tool call with an LLM classifier before running it. The classifier's judgement is shaped by an `autoMode` block in settings: `allow`, `soft_deny` and `hard_deny` rules, plus an `environment` array describing the org, its infrastructure, and what counts as sensitive. Running `/auto-mode-setup` mines the repo, shell history and past denials and writes that block.
+
+It writes it to `~/.claude/settings.json`, which `claudeconfig.sh` regenerates from `claude/roles/` and `claude/stacks/`. Only `enabledPlugins` and `extraKnownMarketplaces` are preserved across a regeneration. Everything else is replaced, so a generated `autoMode` block survives until the next `./claudeconfig.sh` and then disappears without a word.
+
+This is not theoretical. The block generated on 2026-09-08 was gone from `~/.claude/settings.json` within the hour, before any regeneration ran, recovered only because its text was still in the session transcript.
+
+The obvious fix, checking the rules into the repo's own `.claude/settings.json`, does not work. Claude Code reads `autoMode` from user, `--settings` and managed settings only. It looks at project and local settings, and when it finds valid rules there it logs `settings autoMode in projectSettings ignored — only user/flag/managed settings may set classifier rules (projectSettings and localSettings are repo-controllable)` and drops them. A repo you clone must not be able to talk the classifier into trusting it. So these rules have to reach the generated user settings file, which means they have to live in this repo's role sources.
+
+That raises a second problem. The `environment` block is a description of an employer: organization name, internal hostnames, deploy targets, protected namespaces. This repo is public. The home-role picture is fine to publish. The work-role picture is not.
+
+## Decision Drivers
+
+- A silent wipe is the worst failure mode here. Nothing errors, and the classifier quietly falls back to shipped defaults.
+- The two roles need genuinely different answers. A classifier told `Organization: None configured` reads an upload to a company host as an upload to a stranger.
+- Anything shared between home and work should be written once.
+- This repo is public and stays public.
+
+## Considered Options
+
+- Add `autoMode` to the preserved-keys list so regeneration leaves the live block alone.
+- Keep the whole block in `base.jsonc`, one copy for every role.
+- Put the shared part in `base.jsonc`, let roles and stacks contribute the rest, and keep the work-role part in a file outside this repo.
+
+## Decision Outcome
+
+The third option.
+
+**`autoMode` is generated, not preserved.** It joins `permissions` and `sandbox` as a key merged across `base.jsonc`, the active role, every stack, and finally a private overlay. Preserving the live block instead would have left the source of truth in a file that `/auto-mode-setup`, `claude auto-mode reset` and this script all write, with no record of what any of them decided.
+
+**Stacks contribute too.** `beans.jsonc` carries the classifier carve-out for `beans` next to the permissions entry for `beans`, rather than that rule living in `base.jsonc` away from everything else about the tool.
+
+**The arrays concatenate in source order and are never sorted.** This is the opposite of every other array in `claudeconfig.sh`, which ends in `unique | sort`, and the reason is that order carries meaning here:
+
+- `$defaults` is a splice point, not a flag. The settings schema describes it as "include the literal string `$defaults` to inherit the built-in rules at that position". Sorting moves the shipped rules to wherever the sort puts the sentinel.
+- A non-empty `allow`, `soft_deny` or `hard_deny` that lacks `$defaults` **replaces** the shipped rules rather than extending them. A stack adding one narrow carve-out would silently delete every built-in rule. The generator prepends `$defaults` when it is missing.
+- `environment` is a structured document, not a set. Its `### Org-wide` and `### User-specific` headers group the bullets that follow them, and the bullets come from a fixed label list. Sorting scatters bullets out from under their headers.
+
+Because `environment` is header-grouped, plain concatenation is not enough either: home's Org-wide bullets would land after base's User-specific ones. The generator regroups by section, and within a section a later source's bullet **replaces** an earlier one carrying the same `**Label**`, keeping the position the earlier one established. Role beats base, the same way role beats base for every scalar in the script. That is what lets `base.jsonc` hold the shipped "None configured" text for the org-shaped slots (correct as written under the home role) while the work role overrides just the ones that differ.
+
+**The work role's environment lives outside this repo,** at `~/.config/dotpickles/roles/<role>.jsonc`, merged last so it wins over base, role and stacks alike. It is a full role file, not an `autoMode`-only one: same schema, same merge rules.
+
+Outside rather than gitignored inside. A gitignored `claude/roles/work.private.jsonc` would sit one `git add -f` from being public, and would vanish on a fresh clone of dotfiles.
+
+That last risk does not disappear by moving the file, it just changes shape: the overlay is now absent on a machine that has never had one, and the work role would generate with base's placeholder answers. So a role file can declare `"requiresPrivateOverlay": true` and the generator warns loudly when the overlay is missing, matching the existing loud guard for a missing role file. The flag is stripped before writing settings.
+
+### Consequences
+
+- `claude auto-mode reset` and any future `/auto-mode-setup` run write the live file and are undone by the next `./claudeconfig.sh`. The generated-key contract now covers a key that has a CLI actively inviting you to edit it. Port changes back to source.
+- A machine's work-role classifier context is only as good as its overlay, which is hand-carried. There is no sync.
+- `base.jsonc` describes a posture that is accurate at home and placeholder at work. That asymmetry is deliberate and is what the `requiresPrivateOverlay` guard exists to make loud.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -53,3 +53,4 @@
 - [51. nest-wt-worktrees-inside-the-repo](0051-nest-wt-worktrees-inside-the-repo.md)
 - [52. role-scoped-claude-rules](0052-role-scoped-claude-rules.md)
 - [54. sync-authorized-keys-from-1password-for-inbound-ssh](0054-sync-authorized-keys-from-1password-for-inbound-ssh.md)
+- [55. auto-mode-classifier-rules-in-role-sources](0055-auto-mode-classifier-rules-in-role-sources.md)


### PR DESCRIPTION
## Summary

- Auto mode's classifier rules now come from `claude/roles/` and `claude/stacks/` like everything else. `/auto-mode-setup` writes them to `~/.claude/settings.json`, which `claudeconfig.sh` regenerates, and only `enabledPlugins` and `extraKnownMarketplaces` survive a regeneration. The block was living on borrowed time. It actually disappeared on its own partway through writing this, before any regeneration ran, and had to be recovered from a session transcript.
- Checking the rules into `.claude/settings.json` is not an option. Claude Code reads `autoMode` from user, `--settings` and managed settings only. It finds valid rules in project and local settings and deliberately drops them, since a cloned repo must not be able to talk the classifier into trusting it. So they have to reach the generated user settings, which means they have to live in role sources.
- The work role's environment names internal infrastructure, and this repo is public, so it lives at `~/.config/dotpickles/roles/work.jsonc` instead, merged last. Outside the repo rather than gitignored inside it: no `git add -f` can leak it, and it survives a fresh clone. `work.jsonc` sets `requiresPrivateOverlay`, so `claudeconfig.sh` warns loudly when it's missing rather than quietly shipping base's "Organization: None configured" to a work machine.
- Separately, `bin/check-agent-ssh-key` now checks the key ssh would actually use instead of asserting `core.sshCommand`. The home role dropped that override on purpose in d865817, so every `./claudeconfig.sh` run had been ending in a red failure and a non-zero exit after applying everything correctly.

## Why these arrays are special

Two things make `autoMode` unlike the other merged keys, both worth knowing before editing:

`$defaults` is a splice point, not a flag. The schema says "inherit the built-in rules at that position", and an array missing it **replaces** the shipped rules rather than extending them. A stack adding one narrow carve-out would silently delete every built-in rule, so the generator prepends it. This is also why these arrays are never sorted, unlike every other array in the script.

`environment` is a structured document, not a set: `### Org-wide` and `### User-specific` holding `**Label**: value` bullets from a fixed label list. Concatenating alone would file a role's org bullets under the wrong heading, so it regroups by section, and a later source's bullet with a matching `**Label**` overrides the earlier one in place. That override is what lets `base.jsonc` hold the role-invariant picture while roles change only the slots that differ.

Stacks contribute too, so `beans.jsonc` and `taskwarrior.jsonc` each carry the carve-out for their own CLI, next to the permissions entry for it.

## Test plan

Merging was verified with a probe harness that redirects the output file, so live settings were never touched during development:

- home role: full environment, sections in order, no duplicate labels
- work role with no overlay: the warning fires, and `requiresPrivateOverlay` does not leak into settings
- work role with a throwaway overlay: bullets override in place, permissions and sandbox entries land

Then for real: `./claudeconfig.sh` exits clean with all 8 SSH checks passing, and `claude auto-mode config` shows the shipped rules spliced ahead of the three custom allow rules and two soft blocks.

The validator's work-role branch was checked by reading `home/.gitconfig.d/claude-agent-work` directly, since that key isn't on this machine.

## Follow-up work

`dotfiles-1bx8`: create `~/.config/dotpickles/roles/work.jsonc` on the work machine from `/auto-mode-setup`. Until then that role generates with base's placeholder answers, and the script says so on every run.

The taskwarrior allow rule is scoped `in technicalpickles/dotfiles` because that's the scope the recon supported, but taskwarrior is the backlog system everywhere. Left alone rather than silently widening a classifier allow rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efr6KrEvf9tUKTjSD1PK34
