### PR TITLE
Stop invoking osxkeychain twice per credential store

### DIFF
--- a/home/.gitconfig.d/macos
+++ b/home/.gitconfig.d/macos
@@ -1,2 +1,22 @@
+# Xcode's system gitconfig
+# (/Library/Developer/CommandLineTools/usr/share/git-core/gitconfig) already
+# sets credential.helper = osxkeychain, and git runs *every* configured
+# helper. Setting it again here made git invoke osxkeychain twice on every
+# credential store.
+#
+# The empty value first clears whatever earlier scopes contributed, so this
+# file is authoritative: osxkeychain runs exactly once, and it keeps working
+# if Apple's gitconfig ever stops setting it (which deleting this file would
+# have left us silently depending on).
+#
+# Verified 2026-09-09 by counting store attempts. They're normally invisible,
+# because the write succeeds -- under the Claude Code sandbox the keychain
+# write is denied and each attempt prints "failed to store: 100001", which
+# makes them countable: 2 before this change, 1 after.
+#
+# Nothing included ahead of this file sets credential.helper (see the include
+# order in ~/.gitconfig.local, written by gitconfig.sh), so the reset costs
+# nothing today -- but keep that in mind if an earlier include ever wants one.
 [credential]
+	helper =
 	helper = osxkeychain


### PR DESCRIPTION
## Summary

- Xcode's system gitconfig already sets `credential.helper = osxkeychain`, and git runs *every* configured helper, so `~/.gitconfig.d/macos` setting it again meant two invocations on every credential store.
- Resets the inherited value before setting ours rather than deleting the file. Both get down to one invocation, but deleting would leave us silently depending on Apple's gitconfig continuing to set it. The reset keeps this file authoritative.

## Test plan

- A/B against the same remote, counting store attempts: 2 before, 1 after, credential still resolving.
- Those attempts are normally invisible, because the keychain write succeeds. Under an agent sandbox the write is denied and each attempt prints `failed to store: 100001`, which is what makes them countable.
- Checked that nothing included ahead of `macos` in `~/.gitconfig.local` sets `credential.helper`, so the reset doesn't clobber anything today. Worth remembering if an earlier include ever wants one.

## Notes

`git config --get-all credential.helper` is not a useful check here, and it gave me the wrong answer first. The empty-value reset is applied by git's credential machinery when it actually runs the helpers, not by config listing, so `--get-all` still prints every value and makes the reset look like a no-op. Counting real invocations is the only way to see it work.
